### PR TITLE
Feature/tree replacement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "rbox",
     "savetree",
     "treedisplay",
+    "treemodifications",
     "treeparser",
     "treepath",
     "treeserializer",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "savetree",
     "treedisplay",
     "treeparser",
+    "treepath",
     "treeserializer",
     "treeview",
     "truthy",

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ function enqueueLoadTree(source: string | File): void {
             console.log(`Successfully loaded tree: ${name}`);
             // Tree.printNode(result.value, 2);
             setCurrentTree(result.value, name);
+            TreeDisplay.focusTree();
         }
     });
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -4,14 +4,33 @@
 export type NodeType = string
 
 /** Extracts the type of the value of a given field. */
-export type FieldValueType<T extends Field> = T["value"];
+export type FieldValueType<T> = T extends Field ? T["value"] : never;
 
 /**
  * Extracts the element type of the value of a given field.
  * This means if you request the element type for a 'stringArray' field you will get the type 'string'.
  */
-export type FieldElementType<T extends Field> =
-    FieldValueType<T> extends ReadonlyArray<infer U> ? U : FieldValueType<T>;
+export type FieldElementType<T> =
+    T extends Field ? (FieldValueType<T> extends ReadonlyArray<infer U> ? U : FieldValueType<T>) : never;
+
+/** Filters out all non-array fields from a union. */
+export type OnlyArrayField<T> =
+    T extends Field ? (FieldValueType<T> extends ReadonlyArray<infer U> ? T : never) : never;
+
+/** Filter out all array fields from a union. */
+export type OnlyNonArrayField<T> =
+    T extends Field ? (FieldValueType<T> extends ReadonlyArray<infer U> ? never : T) : never;
+
+/** Union type of all possible fields */
+export type Field =
+    StringField |
+    NumberField |
+    BooleanField |
+    NodeField |
+    StringArrayField |
+    NumberArrayField |
+    BooleanArrayField |
+    NodeArrayField
 
 /** Immutable structure representing a single node in the tree */
 export interface Node {
@@ -22,16 +41,6 @@ export interface Node {
     getField(name: string): Field | undefined
     getChild(output: FieldElementIdentifier): Node | undefined;
 }
-
-export type Field =
-    StringField |
-    NumberField |
-    BooleanField |
-    NodeField |
-    StringArrayField |
-    NumberArrayField |
-    BooleanArrayField |
-    NodeArrayField
 
 export interface StringField {
     readonly kind: "string"

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,6 +1,17 @@
 ﻿import * as Utils from "./utils";
 
+/** Identifier for the node-type */
 export type NodeType = string
+
+/** Extracts the type of the value of a given field. */
+export type FieldValueType<T extends Field> = T["value"];
+
+/**
+ * Extracts the element type of the value of a given field.
+ * This means if you request the element type for a 'stringArray' field you will get the type 'string'.
+ */
+export type FieldElementType<T extends Field> =
+    FieldValueType<T> extends ReadonlyArray<infer U> ? U : FieldValueType<T>;
 
 /** Immutable structure representing a single node in the tree */
 export interface Node {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -156,7 +156,7 @@ export function forEachDirectChild(
         switch (field.kind) {
             case "node":
                 const result = callback(field.value, { fieldName: field.name, offset: 0 });
-                if (typeof result == "boolean" && !result)
+                if (typeof result === "boolean" && !result)
                     return;
                 break;
 
@@ -164,7 +164,7 @@ export function forEachDirectChild(
                 for (let arrayIndex = 0; arrayIndex < field.value.length; arrayIndex++) {
                     const node = field.value[arrayIndex];
                     const result = callback(node, { fieldName: field.name, offset: arrayIndex });
-                    if (typeof result == "boolean" && !result)
+                    if (typeof result === "boolean" && !result)
                         return;
                 }
                 break;
@@ -283,9 +283,9 @@ class NodeImpl implements Node {
     getChild(output: FieldElementIdentifier): Node | undefined {
         const field = this.getField(output.fieldName);
         if (field != undefined) {
-            if (field.kind == "node" && output.offset == 0)
+            if (field.kind === "node" && output.offset === 0)
                 return field.value;
-            if (field.kind == "nodeArray")
+            if (field.kind === "nodeArray")
                 return field.value[output.offset];
         }
         return undefined;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -9,6 +9,7 @@ export interface Node {
     readonly fieldNames: ReadonlyArray<string>
 
     getField(name: string): Field | undefined
+    getChild(output: FieldElementIdentifier): Node | undefined;
 }
 
 export type Field =
@@ -69,6 +70,13 @@ export interface NodeArrayField {
     readonly value: ReadonlyArray<Node>
 }
 
+/* Identifier for a single element of a field, for non-arrays the offset will the 0. For arrays the
+offset will be the index into the array. */
+export interface FieldElementIdentifier {
+    readonly fieldName: string
+    readonly offset: number
+}
+
 /** Object that can be used to construct new nodes */
 export interface NodeBuilder {
     pushStringField(name: string, value: string): boolean
@@ -115,14 +123,33 @@ export function getNodeCount(node: Node): number {
  * Execute a callback for each direct child of the given node (no grand-children included).
  * @param node Node to execute callback on.
  * @param callback Callback to execute for each direct child.
+ * Can be short-circuited by returning false from the callback, if void or true is returned the loop
+ * will continue.
  */
-export function forEachDirectChild(node: Node, callback: (node: Node) => void): void {
-    node.fields.forEach(field => {
+export function forEachDirectChild(
+    node: Node,
+    callback: (node: Node, element: FieldElementIdentifier) => boolean | void): void {
+
+    for (let fieldIndex = 0; fieldIndex < node.fields.length; fieldIndex++) {
+        const field = node.fields[fieldIndex];
+
         switch (field.kind) {
-            case "node": callback(field.value); break;
-            case "nodeArray": field.value.forEach(callback); break;
+            case "node":
+                const result = callback(field.value, { fieldName: field.name, offset: 0 });
+                if (typeof result == "boolean" && !result)
+                    return;
+                break;
+
+            case "nodeArray":
+                for (let arrayIndex = 0; arrayIndex < field.value.length; arrayIndex++) {
+                    const node = field.value[arrayIndex];
+                    const result = callback(node, { fieldName: field.name, offset: arrayIndex });
+                    if (typeof result == "boolean" && !result)
+                        return;
+                }
+                break;
         }
-    });
+    }
 }
 
 /**
@@ -132,7 +159,7 @@ export function forEachDirectChild(node: Node, callback: (node: Node) => void): 
  */
 export function getDirectChildren(node: Node): Node[] {
     const result: Node[] = [];
-    forEachDirectChild(node, child => result.push(child));
+    forEachDirectChild(node, child => { result.push(child) });
     return result;
 }
 
@@ -231,6 +258,17 @@ class NodeImpl implements Node {
 
     getField(name: string): Field | undefined {
         return Utils.find(this._fields, field => field.name === name);
+    }
+
+    getChild(output: FieldElementIdentifier): Node | undefined {
+        const field = this.getField(output.fieldName);
+        if (field != undefined) {
+            if (field.kind == "node" && output.offset == 0)
+                return field.value;
+            if (field.kind == "nodeArray")
+                return field.value[output.offset];
+        }
+        return undefined;
     }
 }
 

--- a/src/treedisplay.ts
+++ b/src/treedisplay.ts
@@ -12,6 +12,10 @@ export function setTree(root: Tree.Node): void {
     Display.clear();
     const positionTree = TreeView.createPositionTree(root);
     positionTree.nodes.forEach(n => createDisplay(n, positionTree));
+}
+
+/** Focus the given tree on the display. */
+export function focusTree(): void {
     Display.focusContent();
 }
 

--- a/src/treemodifications.ts
+++ b/src/treemodifications.ts
@@ -1,7 +1,16 @@
 ﻿import * as Utils from "./utils";
 import * as Tree from "./tree";
+import * as TreePath from "./treepath";
 
-export function fieldWithValue<T extends Tree.Field>(
+/**
+ * Create a new field based on a existing field and a new element. If the field is a non-array then
+ * the element is treated as a value, if the field is an array then its treated as one entry in the array.
+ * @param field Original field.
+ * @param element New element.
+ * @param offset If the field is an array then offset defines which index to update.
+ * @returns New field with updated element.
+ */
+export function fieldWithElement<T extends Tree.Field>(
     field: T, element: Tree.FieldElementType<T>, offset: number = 0): T {
 
     switch (field.kind) {
@@ -13,7 +22,58 @@ export function fieldWithValue<T extends Tree.Field>(
             const arrayField = <Tree.OnlyArrayField<T>>field;
             const newValue = Utils.withNewElement(arrayField.value, offset, <Tree.FieldElementType<Tree.Field>>element);
             return <T>{ ...field, value: newValue };
-        default:
-            return <T>{ ...field, value: element };
     }
+
+    return fieldWithValue(field, <Tree.FieldValueType<T>>element);
+}
+
+/**
+ * Create a new field based on a existing field and a new value.
+ * @param field Original field.
+ * @param value New value.
+ * @returns New field with updated value.
+ */
+export function fieldWithValue<T extends Tree.Field>(field: T, value: Tree.FieldValueType<T>): T {
+    return <T>{ ...field, value: value };
+}
+
+/**
+ * Create a new node with a new (or updated) field. If a field with the same name already exists it
+ * will replace it.
+ * @param node Original node.
+ * @param field New field.
+ * @returns New node with updated field.
+ */
+export function nodeWithField(node: Tree.Node, field: Tree.Field): Tree.Node {
+    return Tree.createNode(node.type, b => {
+        node.fields.forEach(orgField => {
+            if (orgField.name === field.name)
+                b.pushField(field);
+            else
+                b.pushField(orgField);
+        });
+    });
+}
+
+/**
+ * Create a new tree based on a existing tree but with a single node replaced with another.
+ * @param root Root of the tree to replace.
+ * @param target Node to replace.
+ * @param newNode Node to replace target with.
+ * @returns New root node for a new tree with a replaced node.
+ */
+export function treeWithReplacedNode(root: Tree.Node, target: Tree.Node, newNode: Tree.Node): Tree.Node {
+    let pathToRoot = TreePath.findPathToRoot(root, target);
+    let node = newNode;
+    pathToRoot.forEach(parent => {
+        node = nodeWithField(parent.node, fieldWithNewNode(parent.node, parent.output, node));
+    });
+    return node;
+}
+
+function fieldWithNewNode(origin: Tree.Node, output: Tree.FieldElementIdentifier, target: Tree.Node): Tree.Field {
+    const orgField = origin.getField(output.fieldName);
+    if (orgField === undefined || (orgField.kind !== "node" && orgField.kind !== "nodeArray"))
+        throw new Error(`Invalid field ${output.fieldName} (Missing or incorrect type)`);
+    return fieldWithElement(orgField, target, output.offset);
 }

--- a/src/treemodifications.ts
+++ b/src/treemodifications.ts
@@ -1,0 +1,19 @@
+﻿import * as Utils from "./utils";
+import * as Tree from "./tree";
+
+export function fieldWithValue<T extends Tree.Field>(
+    field: T, element: Tree.FieldElementType<T>, offset: number = 0): T {
+
+    switch (field.kind) {
+        case "stringArray":
+        case "numberArray":
+        case "booleanArray":
+        case "nodeArray":
+            // Unfortunately the type system cannot follow what we are doing here so some casts are required.
+            const arrayField = <Tree.OnlyArrayField<T>>field;
+            const newValue = Utils.withNewElement(arrayField.value, offset, <Tree.FieldElementType<Tree.Field>>element);
+            return <T>{ ...field, value: newValue };
+        default:
+            return <T>{ ...field, value: element };
+    }
+}

--- a/src/treepath.ts
+++ b/src/treepath.ts
@@ -1,0 +1,57 @@
+﻿import * as Tree from "./tree";
+
+/** Represents an output in the tree (node + field combination). */
+export interface Parent {
+    readonly node: Tree.Node
+    readonly output: Tree.FieldElementIdentifier
+}
+
+/**
+ * Walk the tree to find a path to the root from any given node in the tree.
+ * Will throw if 'target' is not a (grand)child of 'root'.
+ * Note: Potentially requires walking the entire tree starting from 'root'.
+ * @param root Root to start walking from.
+ * @param target Target to walk to.
+ * @returns Path from the target to the root.
+ */
+export function findPathToRoot(root: Tree.Node, target: Tree.Node): Parent[] {
+    let resultPath: Parent[] = [];
+    if (findLeaf(root, target, resultPath))
+        return resultPath;
+    throw new Error("'target' is not a (grand)child of 'root'");
+
+    function findLeaf(node: Tree.Node, target: Tree.Node, path: Parent[]): boolean {
+        if (node == target)
+            return true;
+
+        let found = false;
+        Tree.forEachDirectChild(node, (child, output) => {
+
+            // If this child leads to the target then add this output to the path and return.
+            if (findLeaf(child, target, path)) {
+                path.push({ node: node, output: output });
+                found = true;
+                return false; // Short-circuit the foreach.
+            }
+
+            // Otherwise keep checking the next children.
+            return true;
+        });
+        return found;
+    }
+}
+
+/**
+ * Find the parent of a node given a root.
+ * Will throw if 'target' is not a (grand)child of 'root'.
+ * Note: Potentially requires walking the entire tree starting from 'root'.
+ * @param root Root to start checking from.
+ * @param node Node to find the parent for.
+ * @returns Parent if one is found or undefined if no parent is found.
+ */
+export function getParent(root: Tree.Node, node: Tree.Node): Parent | undefined {
+    const pathToRoot = findPathToRoot(root, node);
+    if (pathToRoot.length == 0)
+        return undefined;
+    return pathToRoot[0];
+}

--- a/src/treepath.ts
+++ b/src/treepath.ts
@@ -21,7 +21,7 @@ export function findPathToRoot(root: Tree.Node, target: Tree.Node): Parent[] {
     throw new Error("'target' is not a (grand)child of 'root'");
 
     function findLeaf(node: Tree.Node, target: Tree.Node, path: Parent[]): boolean {
-        if (node == target)
+        if (node === target)
             return true;
 
         let found = false;
@@ -51,7 +51,7 @@ export function findPathToRoot(root: Tree.Node, target: Tree.Node): Parent[] {
  */
 export function getParent(root: Tree.Node, node: Tree.Node): Parent | undefined {
     const pathToRoot = findPathToRoot(root, node);
-    if (pathToRoot.length == 0)
+    if (pathToRoot.length === 0)
         return undefined;
     return pathToRoot[0];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,22 @@ export function isArray(obj: any): boolean {
 }
 
 /**
+ * Create a new array that contains all the elements from the previous but with the given element
+ * replaced.
+ * @param array Source array.
+ * @param index Index of the element to replace.
+ * @param data Data for the new element.
+ * @returns New array with the changed element.
+ */
+export function withNewElement<T>(array: ReadonlyArray<T>, index: number, data: T): T[] {
+    if (index < 0 || index >= array.length)
+        throw new Error("Given index is outside of the bounds of the array");
+    const result = array.slice();
+    result[index] = data;
+    return result;
+}
+
+/**
  * Find a element in the given array that matches the predicate
  * @param array Array to check
  * @param predicate Predicate to match against elements

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -22,7 +22,7 @@ test("getNodeCount", () => {
 test("forEachDirectChild", () => {
     const testTree = createTestTree();
     const directChildTypes: string[] = [];
-    Tree.forEachDirectChild(testTree, child => directChildTypes.push(child.type));
+    Tree.forEachDirectChild(testTree, child => { directChildTypes.push(child.type) });
 
     expect(directChildTypes).toEqual(["node2", "node4"]);
 });

--- a/tests/treemodifications.test.ts
+++ b/tests/treemodifications.test.ts
@@ -3,48 +3,76 @@ import * as TreeModifications from "../src/treemodifications";
 
 test("fieldWithValueString", () => {
     const field: Tree.StringField = { kind: "string", name: "testName", value: "oldValue" };
-    expect(TreeModifications.fieldWithValue(field, "newValue"))
+    expect(TreeModifications.fieldWithElement(field, "newValue"))
         .toEqual({ kind: "string", name: "testName", value: "newValue" });
 });
 
 test("fieldWithValueNumber", () => {
     const field: Tree.NumberField = { kind: "number", name: "testName", value: 1 };
-    expect(TreeModifications.fieldWithValue(field, 2))
+    expect(TreeModifications.fieldWithElement(field, 2))
         .toEqual({ kind: "number", name: "testName", value: 2 });
 });
 
 test("fieldWithValueBoolean", () => {
     const field: Tree.BooleanField = { kind: "boolean", name: "testName", value: false };
-    expect(TreeModifications.fieldWithValue(field, true))
+    expect(TreeModifications.fieldWithElement(field, true))
         .toEqual({ kind: "boolean", name: "testName", value: true });
 });
 
 test("fieldWithValueNode", () => {
     const field: Tree.NodeField = { kind: "node", name: "testName", value: Tree.createNode("old") };
-    expect(TreeModifications.fieldWithValue(field, Tree.createNode("new")))
+    expect(TreeModifications.fieldWithElement(field, Tree.createNode("new")))
         .toEqual({ kind: "node", name: "testName", value: Tree.createNode("new") });
 });
 
 test("fieldWithValueStringArray", () => {
     const field: Tree.StringArrayField = { kind: "stringArray", name: "testName", value: ["oldValue1", "oldValue2"] };
-    expect(TreeModifications.fieldWithValue(field, "newValue", 1))
+    expect(TreeModifications.fieldWithElement(field, "newValue", 1))
         .toEqual({ kind: "stringArray", name: "testName", value: ["oldValue1", "newValue"] });
 });
 
 test("fieldWithValueNumberArray", () => {
     const field: Tree.NumberArrayField = { kind: "numberArray", name: "testName", value: [1, 2, 3] };
-    expect(TreeModifications.fieldWithValue(field, 1337, 0))
+    expect(TreeModifications.fieldWithElement(field, 1337, 0))
         .toEqual({ kind: "numberArray", name: "testName", value: [1337, 2, 3] });
 });
 
 test("fieldWithValueBooleanArray", () => {
     const field: Tree.BooleanArrayField = { kind: "booleanArray", name: "testName", value: [true, false, true] };
-    expect(TreeModifications.fieldWithValue(field, true, 1))
+    expect(TreeModifications.fieldWithElement(field, true, 1))
         .toEqual({ kind: "booleanArray", name: "testName", value: [true, true, true] });
 });
 
 test("fieldWithValueNodeArray", () => {
     const field: Tree.NodeArrayField = { kind: "nodeArray", name: "testName", value: [Tree.createNode("old1"), Tree.createNode("old2")] };
-    expect(TreeModifications.fieldWithValue(field, Tree.createNode("new"), 0))
+    expect(TreeModifications.fieldWithElement(field, Tree.createNode("new"), 0))
         .toEqual({ kind: "nodeArray", name: "testName", value: [Tree.createNode("new"), Tree.createNode("old2")] });
+});
+
+test("nodeWithField", () => {
+    const node = Tree.createNode("testNode", b => {
+        b.pushStringField("f1", "v1");
+        b.pushStringField("f2", "v2");
+    });
+    expect(TreeModifications.nodeWithField(node, { kind: "string", name: "f2", value: "v3" }))
+        .toEqual(Tree.createNode("testNode", b => {
+            b.pushStringField("f1", "v1");
+            b.pushStringField("f2", "v3");
+        }));
+});
+
+test("treeWithReplacedNode", () => {
+    const innerNodeA = Tree.createNode("innerNode", b => {
+        b.pushStringField("innerFieldA", "innerValueA");
+    });
+    const innerNodeB = Tree.createNode("innerNode", b => {
+        b.pushStringField("innerFieldB", "innerValueB");
+    });
+    const node = Tree.createNode("testNode", b => {
+        b.pushNodeField("child", Tree.createNode("child", b => b.pushNodeField("grandChild", innerNodeA)));
+    });
+    expect(TreeModifications.treeWithReplacedNode(node, innerNodeA, innerNodeB))
+        .toEqual(Tree.createNode("testNode", b => {
+            b.pushNodeField("child", Tree.createNode("child", b => b.pushNodeField("grandChild", innerNodeB)));
+        }));
 });

--- a/tests/treemodifications.test.ts
+++ b/tests/treemodifications.test.ts
@@ -1,0 +1,50 @@
+﻿import * as Tree from "../src/tree";
+import * as TreeModifications from "../src/treemodifications";
+
+test("fieldWithValueString", () => {
+    const field: Tree.StringField = { kind: "string", name: "testName", value: "oldValue" };
+    expect(TreeModifications.fieldWithValue(field, "newValue"))
+        .toEqual({ kind: "string", name: "testName", value: "newValue" });
+});
+
+test("fieldWithValueNumber", () => {
+    const field: Tree.NumberField = { kind: "number", name: "testName", value: 1 };
+    expect(TreeModifications.fieldWithValue(field, 2))
+        .toEqual({ kind: "number", name: "testName", value: 2 });
+});
+
+test("fieldWithValueBoolean", () => {
+    const field: Tree.BooleanField = { kind: "boolean", name: "testName", value: false };
+    expect(TreeModifications.fieldWithValue(field, true))
+        .toEqual({ kind: "boolean", name: "testName", value: true });
+});
+
+test("fieldWithValueNode", () => {
+    const field: Tree.NodeField = { kind: "node", name: "testName", value: Tree.createNode("old") };
+    expect(TreeModifications.fieldWithValue(field, Tree.createNode("new")))
+        .toEqual({ kind: "node", name: "testName", value: Tree.createNode("new") });
+});
+
+test("fieldWithValueStringArray", () => {
+    const field: Tree.StringArrayField = { kind: "stringArray", name: "testName", value: ["oldValue1", "oldValue2"] };
+    expect(TreeModifications.fieldWithValue(field, "newValue", 1))
+        .toEqual({ kind: "stringArray", name: "testName", value: ["oldValue1", "newValue"] });
+});
+
+test("fieldWithValueNumberArray", () => {
+    const field: Tree.NumberArrayField = { kind: "numberArray", name: "testName", value: [1, 2, 3] };
+    expect(TreeModifications.fieldWithValue(field, 1337, 0))
+        .toEqual({ kind: "numberArray", name: "testName", value: [1337, 2, 3] });
+});
+
+test("fieldWithValueBooleanArray", () => {
+    const field: Tree.BooleanArrayField = { kind: "booleanArray", name: "testName", value: [true, false, true] };
+    expect(TreeModifications.fieldWithValue(field, true, 1))
+        .toEqual({ kind: "booleanArray", name: "testName", value: [true, true, true] });
+});
+
+test("fieldWithValueNodeArray", () => {
+    const field: Tree.NodeArrayField = { kind: "nodeArray", name: "testName", value: [Tree.createNode("old1"), Tree.createNode("old2")] };
+    expect(TreeModifications.fieldWithValue(field, Tree.createNode("new"), 0))
+        .toEqual({ kind: "nodeArray", name: "testName", value: [Tree.createNode("new"), Tree.createNode("old2")] });
+});

--- a/tests/treepath.test.ts
+++ b/tests/treepath.test.ts
@@ -1,0 +1,53 @@
+﻿import * as Tree from "../src/tree";
+import * as TreePath from "../src/treepath";
+
+test("findPathToRoot", () => {
+    let nodeToTest: Tree.Node | undefined;
+    const root = Tree.createNode("nodeA", b => {
+        b.pushNodeArrayField("children", [
+            Tree.createNode("childA", b => {
+                b.pushNodeArrayField("grandChildren", [
+                    Tree.createNode("grandChildA"),
+                    Tree.createNode("grandChildB"),
+                    Tree.createNode("grandChildC")
+                ]);
+            }),
+            Tree.createNode("childB", b => {
+                b.pushNodeArrayField("grandChildren", [
+                    Tree.createNode("grandChildA"),
+                    Tree.createNode("grandChildB"),
+                    nodeToTest = Tree.createNode("grandChildC")
+                ]);
+            }),
+            Tree.createNode("childC", b => {
+                b.pushNodeArrayField("grandChildren", [
+                    Tree.createNode("grandChildA"),
+                    Tree.createNode("grandChildB"),
+                    Tree.createNode("grandChildC")
+                ]);
+            })
+        ]);
+    });
+
+    let expectedPath: TreePath.Parent[] = [];
+    expectedPath.unshift({ node: root, output: { fieldName: "children", offset: 1 } });
+    expectedPath.unshift({ node: root.getChild({ fieldName: "children", offset: 1 })!, output: { fieldName: "grandChildren", offset: 2 } });
+
+    expect(TreePath.findPathToRoot(root, nodeToTest!)).toEqual(expectedPath);
+});
+
+test("getParentFindsDirectParent", () => {
+    const root = Tree.createNode("nodeA", b => {
+        b.pushNodeField("nodeField", Tree.createNode("nodeB"));
+        b.pushNodeArrayField("nodeArrayField", [Tree.createNode("nodeC"), Tree.createNode("nodeD")]);
+    });
+    Tree.forEachDirectChild(root, (child, output) => {
+        expect(TreePath.getParent(root, child)).toEqual({ node: root, output: output });
+    });
+});
+
+test("getParentOfUnrelatedNodesThrows", () => {
+    const root = Tree.createNode("nodeA");
+    const node = Tree.createNode("nodeB");
+    expect(() => TreePath.getParent(root, node)).toThrowError();
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,13 @@
 ﻿import * as Utils from "../src/utils";
 
+test("withNewElement", () => {
+    expect(Utils.withNewElement([1, 2, 3], 0, 1337)).toEqual([1337, 2, 3]);
+    expect(Utils.withNewElement([1, 2, 3], 1, 1337)).toEqual([1, 1337, 3]);
+    expect(Utils.withNewElement([1, 2, 3], 2, 1337)).toEqual([1, 2, 1337]);
+    expect(() => Utils.withNewElement([1], -1, 1337)).toThrowError();
+    expect(() => Utils.withNewElement([1], 1, 1337)).toThrowError();
+});
+
 test("find", () => {
     const array = [{ name: "foo", id: 1 }, { name: "bar", id: 2 }, { name: "baz", id: 3 }];
     expect(Utils.find(array, elem => elem.id == 1)).toEqual(array[0]);


### PR DESCRIPTION
Because the tree's are immutable we need a way to easily create new trees based on changes to existing trees.

treemodifications.ts  now contains utilities to create new trees based on existing trees:
```typescript

function fieldWithElement<T extends Tree.Field>(field: T, element: Tree.FieldElementType<T>, offset: number = 0): T

function fieldWithValue<T extends Tree.Field>(field: T, value: Tree.FieldValueType<T>): T

function nodeWithField(node: Tree.Node, field: Tree.Field): Tree.Node

function treeWithReplacedNode(root: Tree.Node, target: Tree.Node, newNode: Tree.Node): Tree.Node
```