### PR TITLE
watch.sh now kill any exising processes on the given TEST_PORT

### DIFF
--- a/ci/watch.sh
+++ b/ci/watch.sh
@@ -16,6 +16,11 @@ autoCompileTypeScript ()
 
 runDevelopmentWebServer ()
 {
+    # Kill all other programs currently occuping that port (our process should not leak as we put
+    # a trap in place but just in case)
+    lsof -n -i4TCP:$TEST_PORT | grep LISTEN | awk '{ print $2 }' | xargs kill
+
+    # Start the 'live-server' (included as a npm package)
     ./node_modules/.bin/live-server build --watch=./* --port=$TEST_PORT
 }
 


### PR DESCRIPTION
Reason for this is that even tho we have a proper trap in place
it can happen that the previous session does not properly gets killed.
(My guess is when vscode is force quited)