### PR TITLE
Feature/robust tree parsing

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -87,13 +87,13 @@ export function initialize(): void {
     window.onkeydown = event => {
         switch (event.key) {
             case "f":
-                if (document.activeElement === null || document.activeElement.tagName != "INPUT")
+                if (document.activeElement === null || document.activeElement.tagName !== "INPUT")
                     focusContent();
                 break;
         }
     };
     window.onmousedown = event => {
-        if (document.activeElement !== null && document.activeElement.tagName == "INPUT")
+        if (document.activeElement !== null && document.activeElement.tagName === "INPUT")
             return;
         dragOffset = Vec.subtract(viewOffset, { x: event.clientX, y: event.clientY });
         dragging = true;
@@ -101,22 +101,22 @@ export function initialize(): void {
     };
     window.onmouseup = () => {
         dragging = false;
-        if (inputBlocker != null)
+        if (inputBlocker !== null)
             inputBlocker.className = "order-back";
     };
     window.onmousemove = event => {
-        if (document.activeElement !== null && document.activeElement.tagName == "INPUT") {
+        if (document.activeElement !== null && document.activeElement.tagName === "INPUT") {
             dragging = false;
             return;
         }
         if (dragging) {
-            if (inputBlocker != null)
+            if (inputBlocker !== null)
                 inputBlocker.className = "order-front";
             setOffset(Vec.add(dragOffset, { x: event.clientX, y: event.clientY }));
         }
     };
     window.onwheel = event => {
-        if (document.activeElement !== null && document.activeElement.tagName == "INPUT")
+        if (document.activeElement !== null && document.activeElement.tagName === "INPUT")
             return;
 
         // Get data from the event
@@ -320,7 +320,7 @@ class GroupElement implements Element {
             addClass(className).
             x(position.x).
             y(position.y);
-        if (clickCallback != undefined)
+        if (clickCallback !== undefined)
             elem.click(clickCallback);
     }
 }

--- a/src/domutils.ts
+++ b/src/domutils.ts
@@ -38,7 +38,7 @@ export function subscribeToFileInput(inputId: string, callback: (file: File) => 
         throw new Error(`Element with id: ${inputId} not found`);
     const inputElement = <HTMLInputElement>element;
     element.onchange = _ => {
-        if (inputElement.files != null && inputElement.files.length > 0)
+        if (inputElement.files !== null && inputElement.files.length > 0)
             callback(inputElement.files[0]);
         inputElement.value = "";
     };

--- a/src/parserutils.ts
+++ b/src/parserutils.ts
@@ -36,7 +36,7 @@ export function loadTextFromFile(file: File): Promise<ParseResult<string>> {
     const fileReader = new FileReader();
     return new Promise((resolve, reject) => {
         fileReader.onload = () => {
-            if (fileReader.result != null && typeof fileReader.result === "string")
+            if (fileReader.result !== null && typeof fileReader.result === "string")
                 resolve(createSuccess(fileReader.result));
             else
                 resolve(createError("File does not contain text"));

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -291,7 +291,7 @@ class NodeImpl implements Node {
 
     getChild(output: FieldElementIdentifier): Node | undefined {
         const field = this.getField(output.fieldName);
-        if (field != undefined) {
+        if (field !== undefined) {
             if (field.kind === "node" && output.offset === 0)
                 return field.value;
             if (field.kind === "nodeArray")

--- a/src/treedisplay.ts
+++ b/src/treedisplay.ts
@@ -121,7 +121,7 @@ function createField(
 
             // Reorder buttons
             parent.addGraphics("fieldValueButton", "arrayOrderUp", { x: nameWidth + 12, y: yPos - 5 }, () => {
-                const newArray = Utils.withSwappedElements(array, i, (i == 0 ? array.length : i) - 1);
+                const newArray = Utils.withSwappedElements(array, i, (i === 0 ? array.length : i) - 1);
                 changed(TreeModifications.fieldWithValue(field, <Tree.FieldValueType<T>><unknown>newArray));
             });
             parent.addGraphics("fieldValueButton", "arrayOrderDown", { x: nameWidth + 12, y: yPos + 5 }, () => {

--- a/src/treeparser.ts
+++ b/src/treeparser.ts
@@ -62,7 +62,7 @@ function parseNode(obj: any): Tree.Node {
 
 function parseField(name: string, value: any): Tree.Field | undefined {
     if (value === undefined || value === null)
-        throw new Error(`Invalid value for key: '${name}'`);
+        return undefined;
 
     switch (typeof value) {
         case "string": return { kind: "string", name: name, value: value };

--- a/src/treeparser.ts
+++ b/src/treeparser.ts
@@ -39,13 +39,15 @@ export function parseJson(jsonString: string): ParseResult<Tree.Node> {
     }
 }
 
+const anonymousNodeType: Tree.NodeType = "Anonymous";
+
 function parseNode(obj: any): Tree.Node {
     if (obj === undefined || obj === null || typeof obj !== "object")
         throw new Error("Invalid input obj");
 
-    const type: any = obj.$type;
+    let type: any = obj.$type;
     if (type === undefined || type === null || typeof type !== "string")
-        throw new Error("Object is missing a '$type' key");
+        type = anonymousNodeType;
 
     return Tree.createNode(type, b => {
         Object.keys(obj).forEach(key => {

--- a/src/treeparser.ts
+++ b/src/treeparser.ts
@@ -49,7 +49,7 @@ function parseNode(obj: any): Tree.Node {
 
     return Tree.createNode(type, b => {
         Object.keys(obj).forEach(key => {
-            if (key != "$type") {
+            if (key !== "$type") {
                 const field = parseField(key, obj[key]);
                 if (field !== undefined)
                     b.pushField(field);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ export function formatJson(json: string): string {
 export function hasDuplicates<T>(input: ReadonlyArray<T>): boolean {
     let hasDuplicates = false;
     input.forEach((value, index) => {
-        hasDuplicates = hasDuplicates || input.indexOf(value) != index;
+        hasDuplicates = hasDuplicates || input.indexOf(value) !== index;
     });
     return hasDuplicates;
 }
@@ -110,7 +110,7 @@ export function hasDuplicates<T>(input: ReadonlyArray<T>): boolean {
  */
 export function findDuplicates<T>(input: ReadonlyArray<T>): T[] {
     return input.reduce((previousValue, currentValue, currentIndex) => {
-        if (input.indexOf(currentValue) != currentIndex && previousValue.indexOf(currentValue) < 0)
+        if (input.indexOf(currentValue) !== currentIndex && previousValue.indexOf(currentValue) < 0)
             previousValue.push(currentValue);
         return previousValue;
     }, new Array<T>());

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -8,7 +8,7 @@ test("cannotPushDuplicateField", () => {
     expect(result.fields.length).toBe(1);
 
     const field = result.getField("testField");
-    if (field != undefined && field.kind == "boolean")
+    if (field !== undefined && field.kind === "boolean")
         expect(field.value).toBeTruthy();
     else
         throw new Error("Field not found");

--- a/tests/treeparser.test.ts
+++ b/tests/treeparser.test.ts
@@ -11,6 +11,18 @@ test("fieldTypeIsParsedSuccessfully", () => {
         expect(nodeParseResult.value).toEqual(Tree.createNode("test"));
 });
 
+test("emptyArraysAreFilteredOut", () => {
+    const json = `{
+        "$type": "test",
+        "field": []
+    }`;
+    const nodeParseResult = Tree̦Parser.parseJson(json);
+    console.log(nodeParseResult);
+    expect(nodeParseResult.kind).toBe("success");
+    if (nodeParseResult.kind == "success")
+        expect(nodeParseResult.value.fields.length).toBe(0);
+});
+
 test("fieldTypeIsRequired", () => {
     const json = `{ }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);

--- a/tests/treeparser.test.ts
+++ b/tests/treeparser.test.ts
@@ -7,7 +7,7 @@ test("fieldTypeIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success")
+    if (nodeParseResult.kind === "success")
         expect(nodeParseResult.value).toEqual(Tree.createNode("test"));
 });
 
@@ -19,7 +19,7 @@ test("emptyArraysAreFilteredOut", () => {
     const nodeParseResult = Tree̦Parser.parseJson(json);
     console.log(nodeParseResult);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success")
+    if (nodeParseResult.kind === "success")
         expect(nodeParseResult.value.fields.length).toBe(0);
 });
 
@@ -45,7 +45,7 @@ test("numberIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushNumberField("num", 42); }));
     }
@@ -58,7 +58,7 @@ test("stringIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushStringField("str", "42"); }));
     }
@@ -71,7 +71,7 @@ test("booleanIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushBooleanField("bool", true); }));
     }
@@ -87,7 +87,7 @@ test("nodeIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => {
                 b.pushNodeField("field", Tree.createNode("child", b => {
@@ -104,7 +104,7 @@ test("numberArrayIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushNumberArrayField("ar", [42, 1337]); }));
     }
@@ -117,7 +117,7 @@ test("stringArrayIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushStringArrayField("ar", ["42", "1337"]); }));
     }
@@ -130,7 +130,7 @@ test("booleanArrayIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => { b.pushBooleanArrayField("ar", [true, false]); }));
     }
@@ -149,7 +149,7 @@ test("nodeArrayIsParsedSuccessfully", () => {
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         expect(nodeParseResult.value).toEqual(
             Tree.createNode("test", b => {
                 b.pushNodeArrayField("field", [Tree.createNode("child", b => {

--- a/tests/treeparser.test.ts
+++ b/tests/treeparser.test.ts
@@ -11,13 +11,23 @@ test("fieldTypeIsParsedSuccessfully", () => {
         expect(nodeParseResult.value).toEqual(Tree.createNode("test"));
 });
 
+test("nullFieldsAreFilteredOut", () => {
+    const json = `{
+        "$type": "test",
+        "field": null
+    }`;
+    const nodeParseResult = Tree̦Parser.parseJson(json);
+    expect(nodeParseResult.kind).toBe("success");
+    if (nodeParseResult.kind === "success")
+        expect(nodeParseResult.value.fields.length).toBe(0);
+});
+
 test("emptyArraysAreFilteredOut", () => {
     const json = `{
         "$type": "test",
         "field": []
     }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
-    console.log(nodeParseResult);
     expect(nodeParseResult.kind).toBe("success");
     if (nodeParseResult.kind === "success")
         expect(nodeParseResult.value.fields.length).toBe(0);

--- a/tests/treeparser.test.ts
+++ b/tests/treeparser.test.ts
@@ -23,19 +23,12 @@ test("emptyArraysAreFilteredOut", () => {
         expect(nodeParseResult.value.fields.length).toBe(0);
 });
 
-test("fieldTypeIsRequired", () => {
+test("fieldTypeDefaultsToAnonymous", () => {
     const json = `{ }`;
     const nodeParseResult = Tree̦Parser.parseJson(json);
-    expect(nodeParseResult.kind).toBe("error");
-});
-
-test("fieldTypeIsRequiredInInnerNode", () => {
-    const json = `{
-        "$type": "test"
-        "node": {}
-    }`;
-    const nodeParseResult = Tree̦Parser.parseJson(json);
-    expect(nodeParseResult.kind).toBe("error");
+    expect(nodeParseResult.kind).toBe("success");
+    if (nodeParseResult.kind === "success")
+        expect(nodeParseResult.value.type).toBe("Anonymous");
 });
 
 test("numberIsParsedSuccessfully", () => {

--- a/tests/treeserializer.test.ts
+++ b/tests/treeserializer.test.ts
@@ -24,7 +24,7 @@ test("savedJsonIsIdenticalToReadJson", () => {
     }`);
     const nodeParseResult = Tree̦Parser.parseJson(json);
     expect(nodeParseResult.kind).toBe("success");
-    if (nodeParseResult.kind == "success") {
+    if (nodeParseResult.kind === "success") {
         const composedJson = TreeSerializer.composeJson(nodeParseResult.value);
         expect(composedJson).toEqual(json);
     }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -27,9 +27,9 @@ test("withSwappedElements", () => {
 
 test("find", () => {
     const array = [{ name: "foo", id: 1 }, { name: "bar", id: 2 }, { name: "baz", id: 3 }];
-    expect(Utils.find(array, elem => elem.id == 1)).toEqual(array[0]);
-    expect(Utils.find(array, elem => elem.id == 2)).toEqual(array[1]);
-    expect(Utils.find(array, elem => elem.id == 3)).toEqual(array[2]);
+    expect(Utils.find(array, elem => elem.id === 1)).toEqual(array[0]);
+    expect(Utils.find(array, elem => elem.id === 2)).toEqual(array[1]);
+    expect(Utils.find(array, elem => elem.id === 3)).toEqual(array[2]);
 });
 
 test("formatJson", () => {


### PR DESCRIPTION
After thinking about it some more i made the tree-parsing more robust. Things that where errors before will now be either filtered out or defaults are used. Advantage is that we can leave the validation to a future scheme system.

Changes:
* `null` fields are now filtered out.
* Nodes that are missing a `$type` property will now get a `Anonymous` type.
* Empty array fields are now filtered out.

Additional advantage for this is that we can now load way more json files.