### PR TITLE
Ignore error when there is no process already listening on our port.

### DIFF
--- a/ci/watch.sh
+++ b/ci/watch.sh
@@ -18,7 +18,7 @@ runDevelopmentWebServer ()
 {
     # Kill all other programs currently occuping that port (our process should not leak as we put
     # a trap in place but just in case)
-    lsof -n -i4TCP:$TEST_PORT | grep LISTEN | awk '{ print $2 }' | xargs kill
+    lsof -n -i4TCP:$TEST_PORT | grep LISTEN | awk '{ print $2 }' | xargs kill 2> /dev/null || true
 
     # Start the 'live-server' (included as a npm package)
     ./node_modules/.bin/live-server build --watch=./* --port=$TEST_PORT


### PR DESCRIPTION
Apparantly on Ubuntu 'kill' doesn't like receiving nothing to kill.