### PR TITLE
Fix csp blocking svg on firefox.

### DIFF
--- a/assets/csp.txt
+++ b/assets/csp.txt
@@ -1,7 +1,2 @@
-default-src 'none';
+default-src 'self';
 script-src 'self' https://unpkg.com;
-connect-src 'self';
-style-src 'self';
-img-src 'self';
-media-src 'self';
-object-src 'self';

--- a/assets/csp.txt
+++ b/assets/csp.txt
@@ -4,3 +4,4 @@ connect-src 'self';
 style-src 'self';
 img-src 'self';
 media-src 'self';
+object-src 'self';

--- a/assets/csp.txt
+++ b/assets/csp.txt
@@ -3,3 +3,4 @@ script-src 'self' https://unpkg.com;
 connect-src 'self';
 style-src 'self';
 img-src 'self';
+media-src 'self';


### PR DESCRIPTION
Seems that firefox has some different rules then chrome.