### PR TITLE
Add undo / redo feature

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -28,6 +28,10 @@
   <button type="button" id="zoomout-button">Zoom (-)</button>
   <button type="button" id="zoomin-button">Zoom (+)</button>
 
+  <!-- Buttons for undo / redo -->
+  <button type="button" id="undo-button">Undo (z)</button>
+  <button type="button" id="redo-button">Redo (shift-z)</button>
+
   <!-- Toolbox containing the main ways to interact with the app -->
   <div id="toolbox">
     <div class="header">Scheme</div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -49,6 +49,10 @@ body button {
     touch-action: manipulation;
 }
 
+body button:disabled {
+    color: #000;
+}
+
 #toolbox-toggle {
     position: absolute;
     left: 5px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -81,6 +81,22 @@ body button {
     height: 25px;
 }
 
+#undo-button {
+    position: absolute;
+    left: 380px;
+    bottom: 5px;
+    width: 125px;
+    height: 25px;
+}
+
+#redo-button {
+    position: absolute;
+    left: 510px;
+    bottom: 5px;
+    width: 125px;
+    height: 25px;
+}
+
 #svg-display {
     width: 100%;
     height: 100%;

--- a/src/app.ts
+++ b/src/app.ts
@@ -195,5 +195,13 @@ function onDomKeyPress(event: KeyboardEvent): void {
         case "f": focusTree(); break;
         case "+": case "=": Display.Tree.zoom(0.1); break;
         case "-": case "_": Display.Tree.zoom(-0.1); break;
+        case "z":
+            if (event.shiftKey) {
+                enqueueRedo();
+            } else {
+                enqueueUndo();
+            }
+            break;
+        case "Z": enqueueRedo(); break;
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -166,6 +166,10 @@ function updateTree(name?: string): void {
             updateTree(name);
         });
     });
+
+    // Update undo / button disabled state
+    Utils.Dom.setButtonDisabled("undo-button", !treeHistory.hasUndo);
+    Utils.Dom.setButtonDisabled("redo-button", !treeHistory.hasRedo);
 }
 
 function toggleToolbox(): void {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -136,6 +136,19 @@ export function subscribeToFileInput(inputId: string, callback: (file: File) => 
 }
 
 /**
+ * Set the disabled property of a button;
+ * @param elementId Id of the button to set the disabled property for.
+ * @param disabled True if the button should be disabled False is the button should be enabled.
+ */
+export function setButtonDisabled(elementId: string, disabled: boolean): void {
+    const element = document.getElementById(elementId);
+    if (element === null || element.nodeName !== "BUTTON") {
+        throw new Error(`Element with id: ${elementId} not found or is not a button`);
+    }
+    (element as HTMLButtonElement).disabled = disabled;
+}
+
+/**
  * Delete all the children of a given node.
  * @param element Element to delete the children from.
  */

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,90 @@
+/**
+ * @file HistoryStack can be used to keep a history for undo / redo purposes.
+ * Usage:
+ * - Create a HistoryStack
+ * - On modifications push new items to it.
+ * - Call undo and get the current from the HistoryStack.
+ */
+
+export interface IHistoryStack<T> {
+    /** Current item in the history. */
+    current: T | undefined;
+
+    /** Is there anything to undo in the history. */
+    hasUndo: boolean;
+
+    /** Is there anything to redo in the history. */
+    hasRedo: boolean;
+
+    /**
+     * Add new items to the history.
+     * @param items New items to add to the history.
+     */
+    push(...items: T[]): void;
+
+    /** Move the current item back to one before. */
+    undo(): void;
+
+    /** Move the current item forward to one later. */
+    redo(): void;
+}
+
+/**
+ * Create a new HistoryStack.
+ * @param maxSize Maximum number of elements in the history.
+ * @returns Newly created HistoryStack.
+ */
+export function createHistoryStack<T>(maxSize: number): IHistoryStack<T> {
+    return new HistoryStackImpl(maxSize);
+}
+
+class HistoryStackImpl<T> implements IHistoryStack<T> {
+    private readonly _maxSize: number;
+    private _items: T[] = [];
+    private _currentIndex: number = -1;
+
+    constructor(maxSize: number) {
+        this._maxSize = maxSize;
+    }
+
+    get current(): T | undefined {
+        if (this._currentIndex < 0) {
+            return undefined;
+        }
+        return this._items[this._currentIndex];
+    }
+
+    get hasUndo(): boolean {
+        return this._currentIndex > 0;
+    }
+
+    get hasRedo(): boolean {
+        return this._items.length > 0 && this._currentIndex < (this._items.length - 1);
+    }
+
+    public push(...items: T[]): void {
+        // Slice of items after currentIndex (as we are starting a alternate history) and remove
+        // items from the front if the collection is too big.
+        if (this._items.length > 0) {
+            this._items = this._items.slice(
+                Math.max(0, (this._currentIndex + items.length + 1) - this._maxSize),
+                this._currentIndex + 1);
+        }
+        // Add the new items.
+        this._items.push(...items);
+        // Set the last item to be the current.
+        this._currentIndex = this._items.length - 1;
+    }
+
+    public undo(): void {
+        if (this._currentIndex > 0) {
+            this._currentIndex--;
+        }
+    }
+
+    public redo(): void {
+        if (this._items.length > 0 && this._currentIndex < (this._items.length - 1)) {
+            this._currentIndex++;
+        }
+    }
+}

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -27,6 +27,9 @@ export interface IHistoryStack<T> {
 
     /** Move the current item forward to one later. */
     redo(): void;
+
+    /** Clear all the items from the history */
+    clear(): void;
 }
 
 /**
@@ -86,5 +89,10 @@ class HistoryStackImpl<T> implements IHistoryStack<T> {
         if (this._items.length > 0 && this._currentIndex < (this._items.length - 1)) {
             this._currentIndex++;
         }
+    }
+
+    public clear(): void {
+        this._items = [];
+        this._currentIndex = -1;
     }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,9 +3,10 @@
  */
 
 import * as Dom from "./dom";
+import * as History from "./history";
 import * as Parser from "./parser";
 import * as Sequencer from "./sequencer";
 import * as Vector from "./vector";
 
 export * from "./misc";
-export { Dom, Parser, Sequencer, Vector };
+export { Dom, History, Parser, Sequencer, Vector };

--- a/tests/integration/app.test.ts
+++ b/tests/integration/app.test.ts
@@ -9,6 +9,7 @@ import * as TreeScheme from "../../src/treescheme";
 describe("app", () => {
     beforeEach(async () => {
         await page.goto("http://localhost:3000");
+        await page.waitFor(100); // Give the page some time to load.
     });
 
     it("should load", async () => {
@@ -20,7 +21,7 @@ describe("app", () => {
         await page.click("#newtree-button");
         await saveScreenshot("newtree");
 
-        // Expect current tree to be first type of the root alias of the scheme
+        // Expect current tree to be first type of the root alias of the scheme.
         const scheme = await getCurrentScheme();
         expect(await getCurrentTree()).toEqual(Tree.createNode(scheme.rootAlias.values[0]));
     });
@@ -35,7 +36,7 @@ describe("app", () => {
         // Set the test-file in the scheme input field.
         FileSystem.writeFileSync("tmp/test.treescheme.json", testScheme);
         (await page.$("#openscheme-file"))!.uploadFile("tmp/test.treescheme.json");
-        await page.waitFor(100); // Give the page some time to respond
+        await page.waitFor(100); // Give the page some time to respond.
 
         const testSchemeParseResult = TreeScheme.Parser.parseJson(testScheme);
         if (testSchemeParseResult.kind === "error") {
@@ -52,7 +53,7 @@ describe("app", () => {
         // Set the test-file in the scheme input field.
         FileSystem.writeFileSync("tmp/test.tree.json", testTree);
         (await page.$("#opentree-file"))!.uploadFile("tmp/test.tree.json");
-        await page.waitFor(100); // Give the page some time to respond
+        await page.waitFor(100); // Give the page some time to respond.
 
         await saveScreenshot("loaded-tree");
         expect(await getCurrentTree()).toEqual(Tree.createNode(scheme.rootAlias.values[0]));
@@ -65,10 +66,30 @@ describe("app", () => {
         await saveScreenshot("change-node-before");
 
         await page.select(".node-type", targetType);
-        await page.waitFor(100); // Give the page some time to respond
+        await page.waitFor(100); // Give the page some time to respond.
 
         await saveScreenshot("change-node-after");
         expect((await getCurrentTree()).type).toBe(targetType);
+    });
+
+    it("can undo changes", async () => {
+        const startingTree = await getCurrentTree();
+        await page.click("#newtree-button");
+        expect(await getCurrentTree()).not.toEqual(startingTree);
+
+        await page.click("#undo-button");
+        expect(await getCurrentTree()).toEqual(startingTree);
+    });
+
+    it("can redo changes", async () => {
+        await page.click("#newtree-button");
+        const newTree = await getCurrentTree();
+
+        await page.click("#undo-button");
+        expect(await getCurrentTree()).not.toEqual(newTree);
+
+        await page.click("#redo-button");
+        expect(await getCurrentTree()).toEqual(newTree);
     });
 
     it("can toggle toolbox visibility", async () => {

--- a/tests/unit/utils/history.test.ts
+++ b/tests/unit/utils/history.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @file Jest tests for utils/history.ts
+ */
+
+import * as Utils from "../../../src/utils";
+
+test("undoRestoresPreviousValues", () => {
+    const history = Utils.History.createHistoryStack<number>(5);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    expect(history.current).toBe(3);
+
+    expect(history.hasUndo).toBe(true);
+    history.undo();
+    expect(history.current).toBe(2);
+
+    expect(history.hasUndo).toBe(true);
+    history.undo();
+    expect(history.current).toBe(1);
+
+    expect(history.hasUndo).toBe(false);
+    history.undo();
+    expect(history.current).toBe(1);
+});
+
+test("redoRestoresFutureValues", () => {
+    const history = Utils.History.createHistoryStack<number>(5);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    expect(history.current).toBe(3);
+
+    history.undo();
+    history.undo();
+    expect(history.current).toBe(1);
+
+    expect(history.hasRedo).toBe(true);
+    history.redo();
+    expect(history.current).toBe(2);
+
+    expect(history.hasRedo).toBe(true);
+    history.redo();
+    expect(history.current).toBe(3);
+
+    expect(history.hasRedo).toBe(false);
+    history.redo();
+    expect(history.current).toBe(3);
+});
+
+test("previousHistoryGetsDiscardedWhenPushingAfterUndo", () => {
+    const history = Utils.History.createHistoryStack<number>(5);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    expect(history.current).toBe(3);
+
+    history.undo();
+    history.undo();
+    expect(history.current).toBe(1);
+
+    history.push(4);
+    expect(history.current).toBe(4);
+
+    history.push(5);
+    expect(history.current).toBe(5);
+
+    history.undo();
+    expect(history.current).toBe(4);
+    history.undo();
+    expect(history.current).toBe(1);
+    history.undo();
+    expect(history.current).toBe(1);
+});
+
+test("tooLongHistoryGetsTruncated", () => {
+    const history = Utils.History.createHistoryStack<number>(3);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    history.push(4);
+    history.push(5);
+    expect(history.current).toBe(5);
+
+    history.undo();
+    expect(history.current).toBe(4);
+
+    history.undo();
+    expect(history.current).toBe(3);
+
+    expect(history.hasUndo).toBe(false);
+    history.undo();
+    expect(history.current).toBe(3);
+});

--- a/tests/unit/utils/history.test.ts
+++ b/tests/unit/utils/history.test.ts
@@ -100,3 +100,17 @@ test("tooLongHistoryGetsTruncated", () => {
     history.undo();
     expect(history.current).toBe(3);
 });
+
+test("clearWipesAllHistory", () => {
+    const history = Utils.History.createHistoryStack<number>(3);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+
+    expect(history.current).toBe(3);
+
+    history.clear();
+    expect(history.current).toBe(undefined);
+});


### PR DESCRIPTION
Adds undo / redo functionality.

Changes:
* `HistoryStack` class for keeping track of previous Tree states.
* undo and redo buttons in the ui for going backwards and forwards in the history.
* Listen for `z` and `shift-z` shortcuts for also triggering the undo / redo.