### PR TITLE
Enum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This editor runs purely client-side and any content you load into it stays purel
     {
       "identifier": "AI.Target",
       "values": [
-        { "value": 0, "name": "Ground" }
-        { "value": 1, "name": "Air" }
+        { "value": 1, "name": "Ground" }
+        { "value": 2, "name": "Air" }
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ This editor runs purely client-side and any content you load into it stays purel
       ]
     }
   ],
+  "enums": [
+    {
+      "identifier": "AI.Target",
+      "values": [
+        { "value": 0, "name": "Ground" }
+        { "value": 1, "name": "Air" }
+      ]
+    }
+  ],
   "nodes": [
     {
       "nodeType": "AI.Items.Selector",
@@ -61,6 +70,7 @@ This editor runs purely client-side and any content you load into it stays purel
 Elements in the scheme:
 * `rootAlias`: Alias that the root-node has to be part of.
 * `aliases`: Definition of all the aliases in the scheme. An alias is a named group of node types.
+* `enums`: Definition of all the enums in the scheme. An enum is a named set of numbers.
 * `nodes`: Definition of all the node-types in the scheme. Each node defines a type-name and a set
 of fields that this node can have.
 
@@ -69,10 +79,11 @@ Possible field value types are:
 * `number`
 * `string`
 * `Alias` (Alias has to be defined in the `aliases` section of the scheme)
+* `Enum` (Enum has to be defined in the `enums` section of the scheme)
 
-Currently only field types that are easily expressed in json are supported. I'm considering
-adding more specialized types like `enum`, `int`, `float` etc, which would have their input filtered
-accordingly.
+Enums are a special type as they only live in the scheme, in the actual tree data they are represented
+by numbers. The fact that the field is an enum in the scheme will make the editor validate the number
+and show it as a dropdown in the ui.
 
 ### Example of the tree output format
 ```json

--- a/assets/example.tree.json
+++ b/assets/example.tree.json
@@ -53,8 +53,8 @@
         {
           "$type": "AI.Items.FindTarget",
           "allowedTargets": [
-            0,
-            1
+            1,
+            2
           ],
           "targetRange": 25,
           "includeBosses": true

--- a/assets/example.tree.json
+++ b/assets/example.tree.json
@@ -53,8 +53,8 @@
         {
           "$type": "AI.Items.FindTarget",
           "allowedTargets": [
-            "Ground",
-            "Air"
+            0,
+            1
           ],
           "targetRange": 25,
           "includeBosses": true

--- a/assets/example.treescheme.json
+++ b/assets/example.treescheme.json
@@ -31,11 +31,11 @@
       "identifier": "AI.Target",
       "values": [
         {
-          "value": 0,
+          "value": 1,
           "name": "Ground"
         },
         {
-          "value": 1,
+          "value": 2,
           "name": "Air"
         }
       ]

--- a/assets/example.treescheme.json
+++ b/assets/example.treescheme.json
@@ -26,6 +26,21 @@
       ]
     }
   ],
+  "enums": [
+    {
+      "identifier": "AI.Target",
+      "values": [
+        {
+          "value": 0,
+          "name": "Ground"
+        },
+        {
+          "value": 1,
+          "name": "Air"
+        }
+      ]
+    }
+  ],
   "nodes": [
     {
       "nodeType": "AI.Items.Selector",
@@ -97,7 +112,7 @@
       "fields": [
         {
           "name": "allowedTargets",
-          "valueType": "string",
+          "valueType": "AI.Target",
           "isArray": true
         },
         {

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -73,6 +73,11 @@
     width: 90%;
 }
 
+#svg-display .enum-value {
+    background-color: #DDD;
+    width: 90%;
+}
+
 #svg-display .boolean-value {
     background-color: #DDD;
     cursor: pointer;

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -161,7 +161,7 @@ function createField(
 
         // Add element button
         parent.addGraphics("fieldvalue-button", "arrayAdd", { x: nameWidth - 15, y: centeredYOffset }, () => {
-            const newElement = TreeScheme.Instantiator.createNewElement(field.kind);
+            const newElement = TreeScheme.Instantiator.createNewElement(fieldDefinition!.valueType);
             const newArray = array.concat(newElement as Tree.FieldElementType<T>);
             changed(Tree.Modifications.fieldWithValue(field, newArray as unknown as Tree.FieldValueType<T>));
         });

--- a/src/display/treescheme.ts
+++ b/src/display/treescheme.ts
@@ -7,58 +7,67 @@ import * as Utils from "../utils";
 
 /** Initialize the display, needs to be done once. */
 export function initialize(): void {
-    if (schemeDisplayElement != null) {
-        throw new Error("Already initialized");
-    }
+  if (schemeDisplayElement != null) {
+    throw new Error("Already initialized");
+  }
 
-    const displayElem = document.getElementById(schemeDisplayElementId);
-    if (displayElem === null) {
-        throw new Error(`No dom element found with id: ${schemeDisplayElementId}`);
-    }
-    schemeDisplayElement = displayElem;
+  const displayElem = document.getElementById(schemeDisplayElementId);
+  if (displayElem === null) {
+    throw new Error(`No dom element found with id: ${schemeDisplayElementId}`);
+  }
+  schemeDisplayElement = displayElem;
 }
 
 export function setScheme(scheme: TreeScheme.IScheme): void {
-    assertInitialized();
-    Utils.Dom.clearChildren(schemeDisplayElement!);
+  assertInitialized();
+  Utils.Dom.clearChildren(schemeDisplayElement!);
 
-    const content = Utils.Dom.createWithChildren("div",
-        Utils.Dom.createWithChildren("div",
-            Utils.Dom.createWithText("span", "Root: ", "header"),
-            Utils.Dom.createWithText("span", scheme.rootAlias.identifier, "identifier")),
-        Utils.Dom.createWithText("span", "Aliases: ", "header"),
-        Utils.Dom.createUList(...scheme.aliases.map(createAliasElement)),
-        Utils.Dom.createWithText("span", "Nodes: ", "header"),
-        Utils.Dom.createUList(...scheme.nodes.map(createNodeElement)));
+  const content = Utils.Dom.createWithChildren("div",
+    Utils.Dom.createWithChildren("div",
+      Utils.Dom.createWithText("span", "Root: ", "header"),
+      Utils.Dom.createWithText("span", scheme.rootAlias.identifier, "identifier")),
+    Utils.Dom.createWithText("span", "Aliases: ", "header"),
+    Utils.Dom.createUList(...scheme.aliases.map(createAliasElement)),
+    Utils.Dom.createWithText("span", "Enums: ", "header"),
+    Utils.Dom.createUList(...scheme.enums.map(createEnumElement)),
+    Utils.Dom.createWithText("span", "Nodes: ", "header"),
+    Utils.Dom.createUList(...scheme.nodes.map(createNodeElement)));
 
-    schemeDisplayElement!.appendChild(content);
+  schemeDisplayElement!.appendChild(content);
 }
 
 const schemeDisplayElementId = "scheme-display";
 let schemeDisplayElement: HTMLElement | undefined;
 
 function createAliasElement(alias: TreeScheme.IAlias): HTMLElement {
-    return Utils.Dom.createWithChildren("details",
-        Utils.Dom.createSummary(alias.identifier, "identifier"),
-        Utils.Dom.createUList(...alias.values.map(f => Utils.Dom.createWithText("span", f, "identifier"))));
+  return Utils.Dom.createWithChildren("details",
+    Utils.Dom.createSummary(alias.identifier, "identifier"),
+    Utils.Dom.createUList(...alias.values.map(f => Utils.Dom.createWithText("span", f, "identifier"))));
+}
+
+function createEnumElement(enumeration: TreeScheme.IEnum): HTMLElement {
+  return Utils.Dom.createWithChildren("details",
+    Utils.Dom.createSummary(enumeration.identifier, "identifier"),
+    Utils.Dom.createUList(...enumeration.values.map(entry =>
+      Utils.Dom.createWithText("span", `${entry.value}: ${entry.name}`, "identifier"))));
 }
 
 function createNodeElement(nodeDefinition: TreeScheme.INodeDefinition): HTMLElement {
-    if (nodeDefinition.fields.length === 0) {
-        return Utils.Dom.createWithText("span", nodeDefinition.nodeType, "identifier");
-    }
-    return Utils.Dom.createWithChildren("details",
-        Utils.Dom.createSummary(nodeDefinition.nodeType, "identifier"),
-        Utils.Dom.createUList(...nodeDefinition.fields.map(f =>
-            Utils.Dom.createWithChildren("div",
-                Utils.Dom.createWithText("span",
-                    f.name, "identifier"),
-                Utils.Dom.createWithText("span",
-                    TreeScheme.getPrettyFieldValueType(f.valueType, f.isArray), "field-type")))));
+  if (nodeDefinition.fields.length === 0) {
+    return Utils.Dom.createWithText("span", nodeDefinition.nodeType, "identifier");
+  }
+  return Utils.Dom.createWithChildren("details",
+    Utils.Dom.createSummary(nodeDefinition.nodeType, "identifier"),
+    Utils.Dom.createUList(...nodeDefinition.fields.map(f =>
+      Utils.Dom.createWithChildren("div",
+        Utils.Dom.createWithText("span",
+          f.name, "identifier"),
+        Utils.Dom.createWithText("span",
+          TreeScheme.getPrettyFieldValueType(f.valueType, f.isArray), "field-type")))));
 }
 
 function assertInitialized(): void {
-    if (schemeDisplayElement === undefined) {
-        throw new Error("Display hasn't been initialized");
-    }
+  if (schemeDisplayElement === undefined) {
+    throw new Error("Display hasn't been initialized");
+  }
 }

--- a/src/treescheme/serializer.ts
+++ b/src/treescheme/serializer.ts
@@ -18,11 +18,19 @@ function createSchemeObject(scheme: TreeScheme.IScheme): object {
     const obj: any = {};
     obj.rootAlias = scheme.rootAlias.identifier;
     obj.aliases = scheme.aliases.map(createAliasObject);
+    obj.enums = scheme.enums.map(createEnumObject);
     obj.nodes = scheme.nodes.map(createNodeObject);
     return obj;
 }
 
 function createAliasObject(alias: TreeScheme.IAlias): object {
+    const obj: any = {};
+    obj.identifier = alias.identifier;
+    obj.values = alias.values;
+    return obj;
+}
+
+function createEnumObject(alias: TreeScheme.IEnum): object {
     const obj: any = {};
     obj.identifier = alias.identifier;
     obj.values = alias.values;
@@ -40,7 +48,9 @@ function createFieldObject(field: TreeScheme.IFieldDefinition): object {
     const obj: any = {};
     obj.name = field.name;
     obj.valueType = createValueTypeString(field.valueType);
-    obj.isArray = field.isArray;
+    if (field.isArray) {
+        obj.isArray = true;
+    }
     return obj;
 }
 

--- a/src/treescheme/treescheme.ts
+++ b/src/treescheme/treescheme.ts
@@ -8,6 +8,25 @@ import * as Utils from "../utils";
 /** Possible types a field can have */
 export type FieldValueType = "string" | "number" | "boolean" | IAlias | IEnum;
 
+/** Extract an identifier out of a FieldValueType */
+export type FieldValueTypeIdentifier<T extends FieldValueType> =
+    T extends string ? T : (T extends IAlias | IEnum ? T["type"] : never);
+
+/** Identifiers for the possible types a field can have */
+export type FieldValueTypeIdentifiers = FieldValueTypeIdentifier<FieldValueType>;
+
+/** Convert a scheme FieldValueType to the corresponding tree field type. */
+export type TreeType<T extends FieldValueType> = ITreeTypeMap[FieldValueTypeIdentifier<T>];
+
+/** Mapping from scheme FieldValueType to types on the tree */
+interface ITreeTypeMap {
+    "string": string;
+    "number": number;
+    "boolean": boolean;
+    "alias": Tree.INode;
+    "enum": number;
+}
+
 /**
  * Tree scheme.
  * Consists out of aliases, enums and nodes.

--- a/src/treescheme/treescheme.ts
+++ b/src/treescheme/treescheme.ts
@@ -129,18 +129,40 @@ export function getPrettyFieldValueType(valueType: FieldValueType, isArray: bool
 }
 
 /**
- * Check if the given 'fieldValueType' is an Alias type.
+ * Validate that the given 'fieldValueType' is an Alias.
  * @param fieldValueType FieldValueType to check.
- * @returns True if the field value is a Alias, otherwise False.
+ * @returns IAlias if the field value is a Alias, otherwise undefined.
  */
-export function isAliasType(fieldValueType: FieldValueType): boolean {
+export function validateAliasType(fieldValueType: FieldValueType): IAlias | undefined {
     switch (fieldValueType) {
         case "string":
         case "number":
         case "boolean":
-            return false;
+            return undefined;
         default:
-            return fieldValueType.type === "alias";
+            if (fieldValueType.type !== "alias") {
+                return undefined;
+            }
+            return fieldValueType;
+    }
+}
+
+/**
+ * Validate that the given 'fieldValueType' is an Enum.
+ * @param fieldValueType FieldValueType to check.
+ * @returns IEnum if the field value is a Enum, otherwise undefined.
+ */
+export function validateEnumType(fieldValueType: FieldValueType): IEnum | undefined {
+    switch (fieldValueType) {
+        case "string":
+        case "number":
+        case "boolean":
+            return undefined;
+        default:
+            if (fieldValueType.type !== "enum") {
+                return undefined;
+            }
+            return fieldValueType;
     }
 }
 

--- a/src/treescheme/treescheme.ts
+++ b/src/treescheme/treescheme.ts
@@ -72,6 +72,7 @@ export interface ISchemeBuilder {
 
     getAlias(identifier: string): IAlias | undefined;
     getEnum(identifier: string): IEnum | undefined;
+    getAliasOrEnum(identifier: string): IAlias | IEnum | undefined;
 
     pushNodeDefinition(nodeType: Tree.NodeType, callback?: (builder: INodeDefinitionBuilder) => void): boolean;
 }
@@ -452,6 +453,14 @@ class SchemeBuilderImpl implements ISchemeBuilder {
 
     public getEnum(identifier: string): IEnum | undefined {
         return Utils.find(this._enums, e => e.identifier === identifier);
+    }
+
+    public getAliasOrEnum(identifier: string): IAlias | IEnum | undefined {
+        const alias = this.getAlias(identifier);
+        if (alias !== undefined) {
+            return alias;
+        }
+        return this.getEnum(identifier);
     }
 
     public pushNodeDefinition(

--- a/src/treescheme/typelookup.ts
+++ b/src/treescheme/typelookup.ts
@@ -93,17 +93,21 @@ class TypeLookupImpl implements ITypeLookup {
         }
         node.fields.forEach(field => {
             const fieldDefinition = definition.getField(field.name);
-            if (fieldDefinition === undefined || !TreeScheme.isAliasType(fieldDefinition.valueType)) {
+            if (fieldDefinition === undefined) {
+                return;
+            }
+            const alias = TreeScheme.validateAliasType(fieldDefinition.valueType);
+            if (alias === undefined) {
                 return;
             }
             switch (field.kind) {
                 case "node":
-                    this._aliases.set(field.value, fieldDefinition.valueType as TreeScheme.IAlias);
+                    this._aliases.set(field.value, alias);
                     this.setAliases(field.value);
                     break;
                 case "nodeArray":
                     field.value.forEach(child => {
-                        this._aliases.set(child, fieldDefinition.valueType as TreeScheme.IAlias);
+                        this._aliases.set(child, alias);
                         this.setAliases(child);
                     });
                     break;

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -113,6 +113,18 @@ export function validateString(obj: any): string | undefined {
 }
 
 /**
+ * Validate if an object is a number.
+ * @param obj Input to validate.
+ * @returns A number if obj was a number otherwise undefined.
+ */
+export function validateNumber(obj: any): number | undefined {
+    if (obj === undefined || obj === null || typeof obj !== "number") {
+        return undefined;
+    }
+    return obj;
+}
+
+/**
  * Validate if an object is a boolean.
  * @param obj Input to validate.
  * @returns A boolean if obj was a boolean otherwise undefined.

--- a/tests/unit/treescheme/instantiator.test.ts
+++ b/tests/unit/treescheme/instantiator.test.ts
@@ -9,9 +9,9 @@ test("missingFieldsAreAppendedCorrectly", () => {
     const scheme = createTestScheme();
     const tree = Tree.createNode("Node1", b => {
         b.pushNumberField("field2", 1337);
-        b.pushNodeArrayField("field8", [
+        b.pushNodeArrayField("field9", [
             Tree.createNode("Node1", b => {
-                b.pushStringArrayField("field5", ["elem1", "elem2"]);
+                b.pushStringArrayField("field6", ["elem1", "elem2"]);
             }),
         ]);
     });
@@ -21,21 +21,25 @@ test("missingFieldsAreAppendedCorrectly", () => {
             b.pushNumberField("field2", 1337);
             b.pushBooleanField("field3", false);
             b.pushNodeField("field4", Tree.createNoneNode());
-            b.pushStringArrayField("field5", []);
-            b.pushNumberArrayField("field6", []);
-            b.pushBooleanArrayField("field7", []);
-            b.pushNodeArrayField("field8", [
+            b.pushNumberField("field5", 1);
+            b.pushStringArrayField("field6", []);
+            b.pushNumberArrayField("field7", []);
+            b.pushBooleanArrayField("field8", []);
+            b.pushNodeArrayField("field9", [
                 Tree.createNode("Node1", b => {
                     b.pushStringField("field1", "");
                     b.pushNumberField("field2", 0);
                     b.pushBooleanField("field3", false);
                     b.pushNodeField("field4", Tree.createNoneNode());
-                    b.pushStringArrayField("field5", ["elem1", "elem2"]);
-                    b.pushNumberArrayField("field6", []);
-                    b.pushBooleanArrayField("field7", []);
-                    b.pushNodeArrayField("field8", []);
+                    b.pushNumberField("field5", 1);
+                    b.pushStringArrayField("field6", ["elem1", "elem2"]);
+                    b.pushNumberArrayField("field7", []);
+                    b.pushBooleanArrayField("field8", []);
+                    b.pushNodeArrayField("field9", []);
+                    b.pushNumberArrayField("field10", []);
                 }),
             ]);
+            b.pushNumberArrayField("field10", []);
         }));
 });
 
@@ -59,9 +63,9 @@ test("whenChangingNodeTypeCompatibleFieldsAreReused", () => {
     const node = Tree.createNode("RandomNode", b => {
         b.pushNumberField("field1", 1234);
         b.pushNumberField("field2", 1337);
-        b.pushNodeArrayField("field8", [
+        b.pushNodeArrayField("field9", [
             Tree.createNode("Node1", b => {
-                b.pushStringArrayField("field5", ["elem1", "elem2"]);
+                b.pushStringArrayField("field6", ["elem1", "elem2"]);
             }),
         ]);
     });
@@ -71,14 +75,16 @@ test("whenChangingNodeTypeCompatibleFieldsAreReused", () => {
             b.pushNumberField("field2", 1337);
             b.pushBooleanField("field3", false);
             b.pushNodeField("field4", Tree.createNoneNode());
-            b.pushStringArrayField("field5", []);
-            b.pushNumberArrayField("field6", []);
-            b.pushBooleanArrayField("field7", []);
-            b.pushNodeArrayField("field8", [
+            b.pushNumberField("field5", 1);
+            b.pushStringArrayField("field6", []);
+            b.pushNumberArrayField("field7", []);
+            b.pushBooleanArrayField("field8", []);
+            b.pushNodeArrayField("field9", [
                 Tree.createNode("Node1", b => {
-                    b.pushStringArrayField("field5", ["elem1", "elem2"]);
+                    b.pushStringArrayField("field6", ["elem1", "elem2"]);
                 }),
             ]);
+            b.pushNumberArrayField("field10", []);
         }));
 });
 
@@ -96,32 +102,45 @@ test("defaultNodeCanBeCreatedSuccessfully", () => {
             b.pushNumberField("field2", 0);
             b.pushBooleanField("field3", false);
             b.pushNodeField("field4", Tree.createNoneNode());
-            b.pushStringArrayField("field5", []);
-            b.pushNumberArrayField("field6", []);
-            b.pushBooleanArrayField("field7", []);
-            b.pushNodeArrayField("field8", []);
+            b.pushNumberField("field5", 1);
+            b.pushStringArrayField("field6", []);
+            b.pushNumberArrayField("field7", []);
+            b.pushBooleanArrayField("field8", []);
+            b.pushNodeArrayField("field9", []);
+            b.pushNumberArrayField("field10", []);
         }));
 });
 
-test("newArrayElementsCanBeCreated", () => {
-    expect(TreeScheme.Instantiator.createNewElement("stringArray")).toEqual("");
-    expect(TreeScheme.Instantiator.createNewElement("numberArray")).toEqual(0);
-    expect(TreeScheme.Instantiator.createNewElement("booleanArray")).toEqual(false);
-    expect(TreeScheme.Instantiator.createNewElement("nodeArray")).toEqual(Tree.createNoneNode());
+test("newElementsCanBeCreated", () => {
+    const scheme = createTestScheme();
+    const node = scheme.nodes[0];
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field1")!.valueType)).toEqual("");
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field2")!.valueType)).toEqual(0);
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field3")!.valueType)).toEqual(false);
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field4")!.valueType)).toEqual(Tree.createNoneNode());
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field5")!.valueType)).toEqual(1);
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field6")!.valueType)).toEqual("");
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field7")!.valueType)).toEqual(0);
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field8")!.valueType)).toEqual(false);
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field9")!.valueType)).toEqual(Tree.createNoneNode());
+    expect(TreeScheme.Instantiator.createNewElement(node.getField("field10")!.valueType)).toEqual(1);
 });
 
 function createTestScheme(): TreeScheme.IScheme {
     return TreeScheme.createScheme("Root", b => {
         const alias = b.pushAlias("Root", ["Node1"]);
+        const enumeration = b.pushEnum("Enum", [{ value: 1, name: "A" }, { value: 2, name: "B" }]);
         b.pushNodeDefinition("Node1", b => {
             b.pushField("field1", "string");
             b.pushField("field2", "number");
             b.pushField("field3", "boolean");
             b.pushField("field4", alias!);
-            b.pushField("field5", "string", true);
-            b.pushField("field6", "number", true);
-            b.pushField("field7", "boolean", true);
-            b.pushField("field8", alias!, true);
+            b.pushField("field5", enumeration!);
+            b.pushField("field6", "string", true);
+            b.pushField("field7", "number", true);
+            b.pushField("field8", "boolean", true);
+            b.pushField("field9", alias!, true);
+            b.pushField("field10", enumeration!, true);
         });
     });
 }

--- a/tests/unit/treescheme/parser.test.ts
+++ b/tests/unit/treescheme/parser.test.ts
@@ -10,15 +10,21 @@ test("basicSchemeIsParsedSuccessfully", () => {
         "aliases": [
             { "identifier": "Alias", "values": [ "NodeA", "NodeB" ] }
         ],
+        "enums": [
+            { "identifier": "Enum", "values": [
+                { "value": 0, "name": "A" }, { "value": 1, "name": "B" }
+            ]}
+        ],
         "nodes": [
             { "nodeType": "NodeA" },
             {
                 "nodeType": "NodeB",
                 "fields": [
-                    { "name": "field1", "valueType": "Alias", "isArray": true },
-                    { "name": "field2", "valueType": "boolean" },
-                    { "name": "field3", "valueType": "string" },
-                    { "name": "field4", "valueType": "number", "isArray": true }
+                    { "name": "field1", "valueType": "boolean" },
+                    { "name": "field2", "valueType": "string" },
+                    { "name": "field3", "valueType": "number", "isArray": true },
+                    { "name": "field4", "valueType": "Alias", "isArray": true },
+                    { "name": "field5", "valueType": "Enum", "isArray": true }
                 ]
             }
         ]
@@ -29,12 +35,14 @@ test("basicSchemeIsParsedSuccessfully", () => {
     if (parseResult.kind === "success") {
         expect(parseResult.value).toEqual(TreeScheme.createScheme("Alias", b => {
             const alias = b.pushAlias("Alias", ["NodeA", "NodeB"]);
+            const enumeration = b.pushEnum("Enum", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
             b.pushNodeDefinition("NodeA");
             b.pushNodeDefinition("NodeB", b => {
-                b.pushField("field1", alias!, true);
-                b.pushField("field2", "boolean");
-                b.pushField("field3", "string");
-                b.pushField("field4", "number", true);
+                b.pushField("field1", "boolean");
+                b.pushField("field2", "string");
+                b.pushField("field3", "number", true);
+                b.pushField("field4", alias!, true);
+                b.pushField("field5", enumeration!, true);
             });
         }));
     }

--- a/tests/unit/treescheme/serializer.test.ts
+++ b/tests/unit/treescheme/serializer.test.ts
@@ -11,6 +11,11 @@ test("savedJsonIsIdenticalToReadJson", () => {
         "aliases": [
             { "identifier": "Alias", "values": [ "NodeA", "NodeB" ] }
         ],
+        "enums": [
+            { "identifier": "Enum", "values": [
+                { "value": 0, "name": "A" }, { "value": 1, "name": "B" }
+            ]}
+        ],
         "nodes": [
             {
                 "nodeType": "NodeA",
@@ -19,10 +24,11 @@ test("savedJsonIsIdenticalToReadJson", () => {
             {
                 "nodeType": "NodeB",
                 "fields": [
-                    { "name": "field1", "valueType": "Alias", "isArray": true },
-                    { "name": "field2", "valueType": "boolean", "isArray": false},
-                    { "name": "field3", "valueType": "string", "isArray": false},
-                    { "name": "field4", "valueType": "number", "isArray": true }
+                    { "name": "field1", "valueType": "boolean" },
+                    { "name": "field2", "valueType": "string" },
+                    { "name": "field3", "valueType": "number", "isArray": true },
+                    { "name": "field4", "valueType": "Alias", "isArray": true },
+                    { "name": "field5", "valueType": "Enum", "isArray": true }
                 ]
             }
         ]

--- a/tests/unit/treescheme/treescheme.test.ts
+++ b/tests/unit/treescheme/treescheme.test.ts
@@ -198,7 +198,7 @@ test("fieldKindMatchesExpectedOutput", () => {
     expect(TreeScheme.getFieldKind(node!.getField("field10")!)).toBe("numberArray");
 });
 
-test("aliasFieldsAreIdentifiedCorrectly", () => {
+test("aliasAndEnumFieldsAreIdentifiedCorrectly", () => {
     const scheme = TreeScheme.createScheme("Alias1", b => {
         const alias = b.pushAlias("Alias1", ["Node1"]);
         const enumeration = b.pushEnum("Enum1", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
@@ -211,11 +211,20 @@ test("aliasFieldsAreIdentifiedCorrectly", () => {
         });
     });
     const node = scheme.getNode("Node1");
-    expect(TreeScheme.isAliasType(node!.getField("field1")!.valueType)).toBe(false);
-    expect(TreeScheme.isAliasType(node!.getField("field2")!.valueType)).toBe(false);
-    expect(TreeScheme.isAliasType(node!.getField("field3")!.valueType)).toBe(false);
-    expect(TreeScheme.isAliasType(node!.getField("field4")!.valueType)).toBe(true);
-    expect(TreeScheme.isAliasType(node!.getField("field5")!.valueType)).toBe(false);
+    expect(TreeScheme.validateAliasType(node!.getField("field1")!.valueType)).toBe(undefined);
+    expect(TreeScheme.validateEnumType(node!.getField("field1")!.valueType)).toBe(undefined);
+
+    expect(TreeScheme.validateAliasType(node!.getField("field2")!.valueType)).toBe(undefined);
+    expect(TreeScheme.validateEnumType(node!.getField("field2")!.valueType)).toBe(undefined);
+
+    expect(TreeScheme.validateAliasType(node!.getField("field3")!.valueType)).toBe(undefined);
+    expect(TreeScheme.validateEnumType(node!.getField("field3")!.valueType)).toBe(undefined);
+
+    expect(TreeScheme.validateAliasType(node!.getField("field4")!.valueType)).not.toBe(undefined);
+    expect(TreeScheme.validateEnumType(node!.getField("field4")!.valueType)).toBe(undefined);
+
+    expect(TreeScheme.validateAliasType(node!.getField("field5")!.valueType)).toBe(undefined);
+    expect(TreeScheme.validateEnumType(node!.getField("field5")!.valueType)).not.toBe(undefined);
 });
 
 test("aliasDefaultReturnsAsExpected", () => {

--- a/tests/unit/treescheme/treescheme.test.ts
+++ b/tests/unit/treescheme/treescheme.test.ts
@@ -13,7 +13,23 @@ test("cannotPushDuplicateAlias", () => {
     });
 
     expect(scheme.aliases.length).toBe(1);
-    expect(scheme.getAlias("testAlias")).toEqual(["Node1"]);
+    expect(scheme.getAlias("testAlias")!.values).toEqual(["Node1"]);
+});
+
+test("cannotPushDuplicateEnum", () => {
+    const scheme = TreeScheme.createScheme("testAlias", b => {
+        b.pushAlias("testAlias", ["Node1"]);
+        b.pushEnum("enum1", [{ value: 0, name: "A" }]);
+
+        // Cannot push enum with the same identifier as an existing enum
+        expect(b.pushEnum("enum1", [{ value: 0, name: "B" }])).toBeFalsy();
+        // Cannot push enum with the same identifier as an existing alias
+        expect(b.pushEnum("testAlias", [{ value: 0, name: "A" }])).toBeFalsy();
+
+        b.pushNodeDefinition("Node1");
+    });
+
+    expect(scheme.enums.length).toBe(1);
 });
 
 test("cannotPushDuplicateNodes", () => {
@@ -60,7 +76,7 @@ test("aliasesCanBeFound", () => {
         b.pushNodeDefinition("Node2");
     });
 
-    expect(scheme.getAlias("Alias1")).toEqual(["Node1", "Node2"]);
+    expect(scheme.getAlias("Alias1")!.values).toEqual(["Node1", "Node2"]);
 });
 
 test("aliasesContainsWorksAsExpected", () => {
@@ -75,6 +91,35 @@ test("aliasesContainsWorksAsExpected", () => {
     expect(alias!.containsValue("Node3")).toBeFalsy();
 });
 
+test("enumsCanBeFound", () => {
+    const scheme = TreeScheme.createScheme("Alias1", b => {
+        b.pushAlias("Alias1", ["Node1"]);
+        b.pushNodeDefinition("Node1");
+
+        b.pushEnum("enum1", [{ value: 0, name: "B" }]);
+    });
+
+    expect(scheme.getEnum("enum1")!.values).toEqual([{ value: 0, name: "B" }]);
+});
+
+test("enumNamesCanBeLookedUp", () => {
+    const scheme = TreeScheme.createScheme("Alias1", b => {
+        b.pushAlias("Alias1", ["Node1"]);
+        b.pushNodeDefinition("Node1");
+
+        b.pushEnum("enum1", [
+            { value: -1, name: "B" },
+            { value: 5, name: "C" },
+            { value: 1337, name: "D" },
+        ]);
+    });
+
+    expect(scheme.getEnum("enum1")!.getName(-1)).toBe("B");
+    expect(scheme.getEnum("enum1")!.getName(5)).toBe("C");
+    expect(scheme.getEnum("enum1")!.getName(1337)).toBe("D");
+    expect(scheme.getEnum("enum1")!.getName(0)).toBe(undefined);
+});
+
 test("fieldCanReferenceAnAlias", () => {
     let alias: TreeScheme.IAlias | undefined;
     const scheme = TreeScheme.createScheme("Alias1", b => {
@@ -86,6 +131,20 @@ test("fieldCanReferenceAnAlias", () => {
     });
 
     expect(scheme.getNode("Node2")!.getField("children")!.valueType).toBe(alias);
+});
+
+test("fieldCanReferenceAnEnum", () => {
+    let enumEntry: TreeScheme.IEnum | undefined;
+    const scheme = TreeScheme.createScheme("Alias1", b => {
+        b.pushAlias("Alias1", ["Node1"]);
+        enumEntry = b.pushEnum("testEnum", [{ value: 0, name: "A" }]);
+
+        b.pushNodeDefinition("Node1", b => {
+            b.pushField("choice", enumEntry!);
+        });
+    });
+
+    expect(scheme.getNode("Node1")!.getField("choice")!.valueType).toBe(enumEntry);
 });
 
 test("fieldsCanBeFound", () => {
@@ -112,6 +171,7 @@ test("fieldsCanBeFound", () => {
 test("fieldKindMatchesExpectedOutput", () => {
     const scheme = TreeScheme.createScheme("Alias1", b => {
         const alias = b.pushAlias("Alias1", ["Node1"]);
+        const enumeration = b.pushEnum("Enum1", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
         b.pushNodeDefinition("Node1", b => {
             b.pushField("field1", "string");
             b.pushField("field2", "string", true);
@@ -121,6 +181,8 @@ test("fieldKindMatchesExpectedOutput", () => {
             b.pushField("field6", "number", true);
             b.pushField("field7", alias!);
             b.pushField("field8", alias!, true);
+            b.pushField("field9", enumeration!);
+            b.pushField("field10", enumeration!, true);
         });
     });
     const node = scheme.getNode("Node1");
@@ -132,16 +194,20 @@ test("fieldKindMatchesExpectedOutput", () => {
     expect(TreeScheme.getFieldKind(node!.getField("field6")!)).toBe("numberArray");
     expect(TreeScheme.getFieldKind(node!.getField("field7")!)).toBe("node");
     expect(TreeScheme.getFieldKind(node!.getField("field8")!)).toBe("nodeArray");
+    expect(TreeScheme.getFieldKind(node!.getField("field9")!)).toBe("number");
+    expect(TreeScheme.getFieldKind(node!.getField("field10")!)).toBe("numberArray");
 });
 
 test("aliasFieldsAreIdentifiedCorrectly", () => {
     const scheme = TreeScheme.createScheme("Alias1", b => {
         const alias = b.pushAlias("Alias1", ["Node1"]);
+        const enumeration = b.pushEnum("Enum1", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
         b.pushNodeDefinition("Node1", b => {
             b.pushField("field1", "string");
             b.pushField("field2", "boolean");
             b.pushField("field3", "number");
             b.pushField("field4", alias!);
+            b.pushField("field5", enumeration!);
         });
     });
     const node = scheme.getNode("Node1");
@@ -149,6 +215,7 @@ test("aliasFieldsAreIdentifiedCorrectly", () => {
     expect(TreeScheme.isAliasType(node!.getField("field2")!.valueType)).toBe(false);
     expect(TreeScheme.isAliasType(node!.getField("field3")!.valueType)).toBe(false);
     expect(TreeScheme.isAliasType(node!.getField("field4")!.valueType)).toBe(true);
+    expect(TreeScheme.isAliasType(node!.getField("field5")!.valueType)).toBe(false);
 });
 
 test("aliasDefaultReturnsAsExpected", () => {

--- a/tests/unit/treescheme/validator.test.ts
+++ b/tests/unit/treescheme/validator.test.ts
@@ -9,13 +9,16 @@ test("validTreeDoesValidate", () => {
     const scheme = TreeScheme.createScheme("Alias1", b => {
         b.pushAlias("Alias1", ["Node1"]);
         const alias2 = b.pushAlias("Alias2", ["Node2"]);
+        const enumeration = b.pushEnum("Enum1", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
 
         b.pushNodeDefinition("Node1", b => {
             b.pushField("field1", alias2!);
+            b.pushField("field2", enumeration!, true);
         });
         b.pushNodeDefinition("Node2", b => {
             b.pushField("field1", "string");
             b.pushField("field2", "number");
+            b.pushField("field3", enumeration!);
         });
     });
 
@@ -23,7 +26,9 @@ test("validTreeDoesValidate", () => {
         b.pushNodeField("field1", Tree.createNode("Node2", b => {
             b.pushStringField("field1", "test");
             b.pushNumberField("field2", 1337);
+            b.pushNumberField("field3", 1);
         }));
+        b.pushNumberArrayField("field2", [0, 1, 1, 0]);
     });
     expect(TreeScheme.Validator.validate(scheme, tree)).toBe(true);
 });
@@ -72,6 +77,22 @@ test("invalidFieldTypeDoesNotValidate", () => {
     const tree = Tree.createNode("Node1", b => {
         b.pushStringField("field2", "test");
         b.pushNumberField("field1", 1337);
+    });
+    expect(TreeScheme.Validator.validate(scheme, tree)).not.toBe(true);
+});
+
+test("invalidEnumValueDoesNotValidate", () => {
+    const scheme = TreeScheme.createScheme("Alias", b => {
+        b.pushAlias("Alias", ["Node1"]);
+        const enumeration = b.pushEnum("Enum1", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
+
+        b.pushNodeDefinition("Node1", b => {
+            b.pushField("field1", enumeration!);
+        });
+    });
+
+    const tree = Tree.createNode("Node1", b => {
+        b.pushNumberField("field1", 2);
     });
     expect(TreeScheme.Validator.validate(scheme, tree)).not.toBe(true);
 });

--- a/tests/unit/utils/parser.test.ts
+++ b/tests/unit/utils/parser.test.ts
@@ -32,6 +32,13 @@ test("validateString", () => {
     expect(Utils.Parser.validateString("test")).toEqual("test");
 });
 
+test("validateNumber", () => {
+    expect(Utils.Parser.validateNumber(null)).toBe(undefined);
+    expect(Utils.Parser.validateNumber(undefined)).toBe(undefined);
+    expect(Utils.Parser.validateNumber(true)).toEqual(undefined);
+    expect(Utils.Parser.validateNumber(1)).toBe(1);
+});
+
 test("validateBoolean", () => {
     expect(Utils.Parser.validateBoolean(null)).toBe(undefined);
     expect(Utils.Parser.validateBoolean(undefined)).toBe(undefined);


### PR DESCRIPTION
Because it's quite common to represent a choice field by an enumeration (many languages have a enum concept). It's basically a named set of numbers, for example value `0` might be called `A` and value `1` might be called `B`.

Enums are supported as a scheme-only feature, so the in the actually tree representation the enums are represented by numbers. Having the field as a enum will make the validation check that the number in the tree actually is in the enum definition and the editor will draw the field with a dropdown instead of a number input.

Work remaining:
* ~~Add data-structures for representing enums to the TreeScheme.~~
* ~~Update the TreeScheme parser to be able to parse enums.~~
* ~~Update the TreeScheme serializer to be to serialize enums.~~
* ~~Update the TreeScheme display to show enums.~~
* ~~Update the example to use at least one enum.~~
* ~~Update the scheme validator to validate enum fields.~~
* ~~Update the tree display to show enum fields as dropdown's instead of number inputs.~~
* ~~Update the instantiator to be able to make default enum values.~~

At this point i have no plans to support flags type enums (where the enum can be multiple values at the same time) but at the same time it wouldn't be impossible to extend this to support flags.