### PR TITLE
Feature/clipboard

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
     "openscheme",
     "opentree",
     "parserutils",
+    "pastetree",
     "polyfill",
     "positionlookup",
     "rbox",
@@ -60,7 +61,7 @@
     "xlink",
     "zoomin",
     "zoomout"
-],
+  ],
   // Search settings
   "search.useIgnoreFiles": false,
   "search.exclude": {},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "callout",
     "classname",
     "codecov",
+    "copytree",
     "crossorigin",
     "devops",
     "domutils",

--- a/assets/index.html
+++ b/assets/index.html
@@ -35,20 +35,22 @@
   <!-- Toolbox containing the main ways to interact with the app -->
   <div id="toolbox">
     <div class="header">Scheme</div>
-    <div id="scheme-display"></div>
     <div class="element" id="openscheme-container">
-      <div id="openscheme-header">Open scheme</div>
       <input type="file" id="openscheme-file" accept=".json" />
+      <button type="button" id="savescheme-button">Save</button>
     </div>
-    <button type="button" class="element" id="savescheme-button">Save scheme</button>
+    <div id="scheme-display"></div>
 
     <div class="header">Tree</div>
-    <button type="button" class="element" id="newtree-button">New tree</button>
     <div class="element" id="opentree-container">
-      <div id="opentree-header">Open tree</div>
+      <button type="button" id="newtree-button">New</button>
       <input type="file" id="opentree-file" accept=".json" />
     </div>
-    <button type="button" class="element" id="savetree-button">Save tree (s)</button>
+    <div class="element" id="savetree-container">
+      <button type="button" id="savetree-button">Save (s)</button>
+      <button type="button" id="copytree-button">Copy 📋</button>
+    </div>
+  </div>
   </div>
 
   <!-- Svg tree content -->

--- a/assets/index.html
+++ b/assets/index.html
@@ -45,6 +45,7 @@
     <div class="element" id="opentree-container">
       <button type="button" id="newtree-button">New</button>
       <input type="file" id="opentree-file" accept=".json" />
+      <button type="button" id="pastetree-button">Paste 📋</button>
     </div>
     <div class="element" id="savetree-container">
       <button type="button" id="savetree-button">Save (s)</button>

--- a/assets/style.css
+++ b/assets/style.css
@@ -36,7 +36,7 @@ html, html > body {
     text-decoration: none;
 }
 
-body button {
+body > button {
     font-size: 12px;
     border-radius: 8px;
     border: 4px solid #000;

--- a/assets/toolboxstyle.css
+++ b/assets/toolboxstyle.css
@@ -8,7 +8,7 @@
     background-color: #888;
 }
 
-#toolbox > .element {
+#toolbox .element {
     margin-top: 5px;
     margin-bottom: 5px;
     margin-left: 2.5%;
@@ -16,28 +16,32 @@
     width: 95%;
     background-color: #DDD;
     border-radius: 4px;
-    font-weight: bold;
 }
 
 /* Show cursor on buttons in the toolbox */
 #toolbox button {
     cursor: pointer;
     color: #000;
+    line-height: 15px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    margin-left: 2.5%;
+    margin-right: 2.5%;
+    width: 95%;
 }
 
-#toolbox #openscheme-container, #toolbox #opentree-container {
+#toolbox input {
+    display: inline-block;
+    width: 200px;
+    min-width: 200px;
+    font-size: 10pt;
+    margin-left: 2.5%;
+    margin-right: 2.5%;
+}
+
+#toolbox #openscheme-container, #toolbox #opentree-container, #toolbox #savetree-container {
     display: flex;
     align-items: center;
-    text-align: center;
-    font-size: 10pt;
-}
-
-#toolbox #openscheme-container #openscheme-header, #toolbox #opentree-container #opentree-header {
-    width: 30%
-}
-
-#toolbox #openscheme-container #openscheme-file, #toolbox #opentree-container #opentree-file {
-    width: 70%;
 }
 
 #toolbox > .header {

--- a/assets/toolboxstyle.css
+++ b/assets/toolboxstyle.css
@@ -2,7 +2,7 @@
     position: absolute;
     left: 5px;
     bottom: 35px;
-    width: 300px;
+    width: 360px;
     border-radius: 8px;
     border: 4px solid #000;
     background-color: #888;
@@ -11,9 +11,9 @@
 #toolbox .element {
     margin-top: 5px;
     margin-bottom: 5px;
-    margin-left: 2.5%;
-    margin-right: 2.5%;
-    width: 95%;
+    margin-left: 1%;
+    margin-right: 1%;
+    width: 98%;
     background-color: #DDD;
     border-radius: 4px;
 }
@@ -25,18 +25,18 @@
     line-height: 15px;
     margin-top: 5px;
     margin-bottom: 5px;
-    margin-left: 2.5%;
-    margin-right: 2.5%;
-    width: 95%;
+    margin-left: 1%;
+    margin-right: 1%;
+    width: 98%;
 }
 
 #toolbox input {
     display: inline-block;
-    width: 200px;
-    min-width: 200px;
+    width: 175px;
+    min-width: 175px;
     font-size: 10pt;
-    margin-left: 2.5%;
-    margin-right: 2.5%;
+    margin-left: 1%;
+    margin-right: 1%;
 }
 
 #toolbox #openscheme-container, #toolbox #opentree-container, #toolbox #savetree-container {

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ export async function run(): Promise<void> {
     Utils.Dom.subscribeToClick("newtree-button", enqueueNewTree);
     Utils.Dom.subscribeToFileInput("opentree-file", enqueueLoadTree);
     Utils.Dom.subscribeToClick("savetree-button", enqueueSaveTree);
+    Utils.Dom.subscribeToClick("copytree-button", enqueueCopyTreeToClipboard);
 
     console.log("Started running");
 
@@ -136,6 +137,21 @@ function enqueueSaveTree(): void {
     });
 }
 
+function enqueueCopyTreeToClipboard(): void {
+    sequencer.enqueue(async () => {
+        if (treeHistory.current !== undefined) {
+            const treeJson = Tree.Serializer.composeJson(treeHistory.current);
+            try {
+                await Utils.Dom.writeClipboardText(treeJson);
+            } catch (e) {
+                alert(`Unable to copy: ${e}`);
+            }
+            hasUnsavedChanges = false;
+            updateTreeTitle();
+        }
+    });
+}
+
 function enqueueUndo(): void {
     sequencer.enqueue(async () => {
         treeHistory.undo();
@@ -213,6 +229,7 @@ function onDomKeyPress(event: KeyboardEvent): void {
         case "t": toggleToolbox(); break;
         case "f": focusTree(); break;
         case "s": enqueueSaveTree(); break;
+        case "c": enqueueCopyTreeToClipboard(); break;
         case "+": case "=": Display.Tree.zoom(0.1); break;
         case "-": case "_": Display.Tree.zoom(-0.1); break;
         case "z":

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -23,6 +23,33 @@ export function saveJsonText(json: string, fileName: string): void {
 }
 
 /**
+ * Read string from clipboard. User is prompted for permission first, throws if permission was not provided.
+ * Note: Not supported on all browsers.
+ * @returns Promise that contains the string that was read.
+ */
+export function readClipboardText(): Promise<string> {
+    const clipboard = (navigator as any).clipboard;
+    if (clipboard === undefined) {
+        throw new Error("Clipboard api not supported");
+    }
+    return clipboard.readText();
+}
+
+/**
+ * Write string to clipboard. User is prompted for permission first, throws if permission was not provided.
+ * Note: Not supported on all browsers.
+ * @param data Data to write to the clipboard.
+ * @returns Promise that completes when the data is written.
+ */
+export function writeClipboardText(data: string): Promise<void> {
+    const clipboard = (navigator as any).clipboard;
+    if (clipboard === undefined) {
+        throw new Error("Clipboard api not supported");
+    }
+    return clipboard.writeText(data);
+}
+
+/**
  * Get the mouse-wheel delta normalized across browsers. Tries to estimate how far was scrolled
  * relative to the wheel (1 = a single spin of the wheel) This allows for consistent scroll speeds
  * across different browsers.

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -29,7 +29,7 @@ export function saveJsonText(json: string, fileName: string): void {
  */
 export function readClipboardText(): Promise<string> {
     const clipboard = (navigator as any).clipboard;
-    if (clipboard === undefined) {
+    if (clipboard === undefined || typeof clipboard.readText !== "function") {
         throw new Error("Clipboard api not supported");
     }
     return clipboard.readText();
@@ -43,7 +43,7 @@ export function readClipboardText(): Promise<string> {
  */
 export function writeClipboardText(data: string): Promise<void> {
     const clipboard = (navigator as any).clipboard;
-    if (clipboard === undefined) {
+    if (clipboard === undefined || typeof clipboard.writeText !== "function") {
         throw new Error("Clipboard api not supported");
     }
     return clipboard.writeText(data);


### PR DESCRIPTION
Support copy/paste of tree's from the clipboard. Implemented using the [clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) api. This is fully working on the latest Chrome (from 66 actually) and Firefox supports copying to clipboard (but no paste yet as of this moment). Note: Users are prompted for permission first.