### PR TITLE
Set explicit font-size for node-type dropdown.

### DIFF
--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -17,6 +17,7 @@
 #svg-display .node-type {
     font-weight: bold;
     margin-left: 5%;
+    font-size: 10px;
     width: 90%;
     height: 90%;
     background-color: #DDD;


### PR DESCRIPTION
On FireFox it did not fit with the default sizing.