### PR TITLE
Feature/scheme drop

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -252,9 +252,12 @@ function focusTree(): void {
 function onDrag(event: DragEvent): void {
     // If a file was dropped then load it as a tree.
     if (event.dataTransfer !== null && event.dataTransfer.files !== null && event.dataTransfer.files.length) {
-        // Note: It would actually be possible to conditionally load a tree or a scheme based on a file
-        // naming convention, need to give it some more thought wether or not thats a good idea.
-        enqueueLoadTree(event.dataTransfer.files[0]);
+        const file = event.dataTransfer.files[0];
+        if (file.name.includes("scheme")) {
+            enqueueLoadScheme(file);
+        } else {
+            enqueueLoadTree(file);
+        }
     }
 
     // Prevent default drag and drop behaviour

--- a/src/app.ts
+++ b/src/app.ts
@@ -180,11 +180,18 @@ function setCurrentScheme(scheme: TreeScheme.IScheme, name: string): void {
     currentSchemeName = name;
     Display.TreeScheme.setScheme(currentScheme);
 
-    // Loading a new scheme invalidates the current tree. (In theory we could support checking if the
-    // previously loaded tree is still compatible with the new scheme)
+    // Loading a new scheme invalidates the current tree so we clear the tree history.
     treeHistory.clear();
-    currentTreeName = undefined;
+
+    // Create a new default tree based on the newly loaded scheme.
+    const defaultRoot = TreeScheme.getDefaultDefinition(scheme, scheme.rootAlias);
+    const newRoot = TreeScheme.Instantiator.instantiateDefaultNode(defaultRoot);
+    treeHistory.push(newRoot);
+
+    hasUnsavedChanges = false;
+    currentTreeName = "new.tree.json";
     updateTree();
+    Display.Tree.focusTree(1);
 }
 
 function openTree(tree: Tree.INode): void {


### PR DESCRIPTION
Allow dropping scheme files on the page. We determine if it's a scheme by looking if the filename contains 'scheme'. Also when loading a new scheme start with a new tree instead of an empty page.