### PR TITLE
Feature/tooltip

### DIFF
--- a/assets/example.treescheme.json
+++ b/assets/example.treescheme.json
@@ -44,6 +44,7 @@
   "nodes": [
     {
       "nodeType": "AI.Items.Selector",
+      "comment": "Invoke the first child that succeeds",
       "fields": [
         {
           "name": "children",
@@ -54,6 +55,7 @@
     },
     {
       "nodeType": "AI.Items.Sequence",
+      "comment": "Invoke all children in sequence (the first one that fails stops the chain)",
       "fields": [
         {
           "name": "children",
@@ -64,6 +66,7 @@
     },
     {
       "nodeType": "AI.Items.Condition",
+      "comment": "Invoke the child is the given conditions are true",
       "fields": [
         {
           "name": "conditions",
@@ -171,6 +174,7 @@
     },
     {
       "nodeType": "AI.Conditions.IsAbilityCharged",
+      "comment": "Checks if there is a ability charged",
       "fields": [
         {
           "name": "abilityId",

--- a/assets/index.html
+++ b/assets/index.html
@@ -98,5 +98,11 @@
       <path d="M -2.5 -2.5 L 0 2.5 L 2.5 -2.5 z" fill="#000" stroke="none" />
     </g>
 
+    <g id="info">
+      <circle cx="0" cy="0" r="7" fill="#DDD" stroke="#000" />
+      <circle cx="0" cy="-3.5" r="1.5" fill="#000" />
+      <path d="M 0 4.5 L 0 -1 z" fill="none" stroke="#000" stroke-width="2" />
+    </g>
+
   </defs>
 </svg>

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -24,6 +24,28 @@
     cursor: pointer;
 }
 
+/* Tooltip */
+#svg-display .node-info:hover .node-tooltip {
+    visibility: visible;
+}
+
+#svg-display .node-info .node-tooltip {
+    visibility: hidden;
+}
+
+#svg-display .node-tooltip-text {
+    display: inline-block;
+    font-size: 10px;
+    line-height: 12px;
+    padding: 5px;
+}
+
+#svg-display .node-tooltip-background {
+    fill: #DDD;
+    stroke: #000;
+    stroke-width: 2px;
+}
+
 /* Field backgrounds */
 #svg-display .string-value-background, #svg-display .stringArray-value-background {
     fill: #696;

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 2;
+const version = 3;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/src/display/svg.ts
+++ b/src/display/svg.ts
@@ -322,6 +322,7 @@ class GroupElement implements IElement {
 
     constructor(parent: Element, className: Utils.Dom.ClassName, position: Vector.Position) {
         this._svgGroup = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        this._svgGroup.classList.add(className);
         this._svgGroup.setAttribute("transform", `translate(${position.x}, ${position.y})`);
         parent.appendChild(this._svgGroup);
 

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -59,6 +59,7 @@ const nodeHeaderHeight = Tree.PositionLookup.nodeHeaderHeight;
 const halfNodeHeaderHeight = Utils.half(nodeHeaderHeight);
 const nodeFieldHeight = Tree.PositionLookup.nodeFieldHeight;
 const nodeInputSlotOffset: Vector.IVector2 = { x: 0, y: 12.5 };
+const nodeTooltipSize: Vector.IVector2 = { x: 400, y: 150 };
 const nodeConnectionCurviness = .7;
 
 type nodeChangedCallback = (newNode: Tree.INode) => void;
@@ -86,8 +87,8 @@ function createNode(
         typeOptionsIndex,
         typeOptions,
         /* Ugly offsets to compensate for styling of select elements */
-        { x: 0, y: halfNodeHeaderHeight - 3 },
-        { x: size.x, y: nodeHeaderHeight - 5 },
+        { x: 10, y: halfNodeHeaderHeight - 3 },
+        { x: size.x - 10, y: nodeHeaderHeight - 5 },
         newIndex => {
             const newNodeType = typeOptions[newIndex];
             const newNode = TreeScheme.Instantiator.changeNodeType(typeLookup.scheme, node, newNodeType);
@@ -100,6 +101,19 @@ function createNode(
             changed(Tree.Modifications.nodeWithField(node, newField));
         });
     });
+
+    if (definition !== undefined && definition.comment !== undefined) {
+        const infoElement = nodeElement.addElement("node-info", Vector.zeroVector);
+        infoElement.addGraphics("node-info-button", "info", { x: 12, y: halfNodeHeaderHeight });
+
+        const toolTipElement = infoElement.addElement("node-tooltip", { x: 25, y: -100 });
+        toolTipElement.addRect("node-tooltip-background", nodeTooltipSize, Vector.zeroVector);
+        toolTipElement.addText(
+            "node-tooltip-text",
+            definition.comment,
+            { x: 0, y: Utils.half(nodeTooltipSize.y) },
+            nodeTooltipSize);
+    }
 }
 
 type fieldChangedCallback<T extends Tree.Field> = (newField: T) => void;

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -59,7 +59,7 @@ const nodeHeaderHeight = Tree.PositionLookup.nodeHeaderHeight;
 const halfNodeHeaderHeight = Utils.half(nodeHeaderHeight);
 const nodeFieldHeight = Tree.PositionLookup.nodeFieldHeight;
 const nodeInputSlotOffset: Vector.IVector2 = { x: 0, y: 12.5 };
-const nodeTooltipSize: Vector.IVector2 = { x: 400, y: 150 };
+const nodeTooltipSize: Vector.IVector2 = { x: 400, y: 75 };
 const nodeConnectionCurviness = .7;
 
 type nodeChangedCallback = (newNode: Tree.INode) => void;
@@ -106,7 +106,7 @@ function createNode(
         const infoElement = nodeElement.addElement("node-info", Vector.zeroVector);
         infoElement.addGraphics("node-info-button", "info", { x: 12, y: halfNodeHeaderHeight });
 
-        const toolTipElement = infoElement.addElement("node-tooltip", { x: 25, y: -100 });
+        const toolTipElement = infoElement.addElement("node-tooltip", { x: 25, y: -26 });
         toolTipElement.addRect("node-tooltip-background", nodeTooltipSize, Vector.zeroVector);
         toolTipElement.addText(
             "node-tooltip-text",

--- a/src/treescheme/parser.ts
+++ b/src/treescheme/parser.ts
@@ -135,6 +135,9 @@ function parseNodes(schemeBuilder: TreeScheme.ISchemeBuilder, obj: any): void {
         }
 
         schemeBuilder.pushNodeDefinition(nodeType, nodeBuilder => {
+            // Parse optional comment
+            nodeBuilder.comment = Utils.Parser.validateString(nodeObj.comment);
+
             // Parse fields
             if (!Utils.Parser.isArray(nodeObj.fields)) {
                 return;

--- a/src/treescheme/treescheme.ts
+++ b/src/treescheme/treescheme.ts
@@ -99,6 +99,8 @@ export interface ISchemeBuilder {
 
 /** Builder that can be used to create a node definition */
 export interface INodeDefinitionBuilder {
+    comment: string | undefined;
+
     pushField(name: string, valueType: FieldValueType, isArray?: boolean): boolean;
 }
 
@@ -412,9 +414,10 @@ class EnumImpl implements IEnum {
 
 class NodeDefinitionImpl implements INodeDefinition {
     private readonly _nodeType: Tree.NodeType;
+    private readonly _comment: string | undefined;
     private readonly _fields: ReadonlyArray<IFieldDefinition>;
 
-    constructor(nodeType: Tree.NodeType, fields: ReadonlyArray<IFieldDefinition>) {
+    constructor(nodeType: Tree.NodeType, comment: string | undefined, fields: ReadonlyArray<IFieldDefinition>) {
         // Verify that this nodescheme has a nodetype
         if (nodeType === "") {
             throw new Error("NodeDefinition must have an type");
@@ -425,11 +428,12 @@ class NodeDefinitionImpl implements INodeDefinition {
         }
 
         this._nodeType = nodeType;
+        this._comment = comment;
         this._fields = fields;
     }
 
     get comment(): string | undefined {
-        return undefined;
+        return this._comment;
     }
 
     get nodeType(): string {
@@ -524,7 +528,7 @@ class SchemeBuilderImpl implements ISchemeBuilder {
         }
 
         if (callback === undefined) {
-            this._nodes.push(new NodeDefinitionImpl(nodeType, []));
+            this._nodes.push(new NodeDefinitionImpl(nodeType, undefined, []));
         } else {
             const builder = new NodeDefinitionBuilderImpl(nodeType);
             callback(builder);
@@ -545,12 +549,21 @@ class SchemeBuilderImpl implements ISchemeBuilder {
 
 class NodeDefinitionBuilderImpl implements INodeDefinitionBuilder {
     private readonly _nodeType: Tree.NodeType;
+    private _comment: string | undefined;
     private _fields: IFieldDefinition[];
     private _build: boolean;
 
     constructor(nodeType: Tree.NodeType) {
         this._nodeType = nodeType;
         this._fields = [];
+    }
+
+    get comment(): string | undefined {
+        return this._comment;
+    }
+
+    set comment(value: string | undefined) {
+        this._comment = value;
     }
 
     public pushField(name: string, valueType: FieldValueType, isArray?: boolean): boolean {
@@ -574,6 +587,6 @@ class NodeDefinitionBuilderImpl implements INodeDefinitionBuilder {
 
     public build(): INodeDefinition {
         this._build = true;
-        return new NodeDefinitionImpl(this._nodeType, this._fields);
+        return new NodeDefinitionImpl(this._nodeType, this._comment, this._fields);
     }
 }

--- a/src/treescheme/treescheme.ts
+++ b/src/treescheme/treescheme.ts
@@ -71,6 +71,7 @@ export interface IEnum {
 
 /** Definition of a node (what kind of fields it has) */
 export interface INodeDefinition {
+    readonly comment: string | undefined;
     readonly nodeType: Tree.NodeType;
     readonly fields: ReadonlyArray<IFieldDefinition>;
 
@@ -425,6 +426,10 @@ class NodeDefinitionImpl implements INodeDefinition {
 
         this._nodeType = nodeType;
         this._fields = fields;
+    }
+
+    get comment(): string | undefined {
+        return undefined;
     }
 
     get nodeType(): string {

--- a/tests/unit/treescheme/parser.test.ts
+++ b/tests/unit/treescheme/parser.test.ts
@@ -19,6 +19,7 @@ test("basicSchemeIsParsedSuccessfully", () => {
             { "nodeType": "NodeA" },
             {
                 "nodeType": "NodeB",
+                "comment": "This is a very useful node",
                 "fields": [
                     { "name": "field1", "valueType": "boolean" },
                     { "name": "field2", "valueType": "string" },
@@ -38,6 +39,7 @@ test("basicSchemeIsParsedSuccessfully", () => {
             const enumeration = b.pushEnum("Enum", [{ value: 0, name: "A" }, { value: 1, name: "B" }]);
             b.pushNodeDefinition("NodeA");
             b.pushNodeDefinition("NodeB", b => {
+                b.comment = "This is a very useful node";
                 b.pushField("field1", "boolean");
                 b.pushField("field2", "string");
                 b.pushField("field3", "number", true);


### PR DESCRIPTION
Add optional `comment` field to nodes in the tree-scheme. If a comment is set it will be displayed as a tooltip on the nodes.

Reasoning is that it provides a way for the creator of nodes to document how nodes should be used.