### PR TITLE
Feature/preserve state when loading compatible scheme

### DIFF
--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 6;
+const version = 7;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/src/treescheme/instantiator.ts
+++ b/src/treescheme/instantiator.ts
@@ -24,6 +24,11 @@ export function duplicateWithMissingFields(scheme: TreeScheme.IScheme, tree: Tre
     return instantiateNode(tree);
 
     function instantiateNode(node: Tree.INode): Tree.INode {
+        // If node is of type 'none' it cannot have any data and we leave it alone.
+        if (node.type === Tree.noneNodeType) {
+            return node;
+        }
+
         // Get the definition for this node from the scheme.
         const definition = scheme.getNode(node.type);
         if (definition === undefined) {

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -33,6 +33,9 @@ export interface IHistoryStack<T> {
 
     /** Delete all items that do not match the given predicate */
     prune(predicate: (state: T) => boolean): void;
+
+    /** Perform the given mutation on all elements in the history */
+    map(mutation: (state: T) => T): void;
 }
 
 /**
@@ -111,5 +114,9 @@ class HistoryStackImpl<T> implements IHistoryStack<T> {
                 i--;
             }
         }
+    }
+
+    public map(mutation: (state: T) => T): void {
+        this._items = this._items.map(mutation);
     }
 }

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -30,6 +30,9 @@ export interface IHistoryStack<T> {
 
     /** Clear all the items from the history */
     clear(): void;
+
+    /** Delete all items that do not match the given predicate */
+    prune(predicate: (state: T) => boolean): void;
 }
 
 /**
@@ -94,5 +97,19 @@ class HistoryStackImpl<T> implements IHistoryStack<T> {
     public clear(): void {
         this._items = [];
         this._currentIndex = -1;
+    }
+
+    public prune(predicate: (state: T) => boolean): void {
+        // Apply predicate to entire history.
+        for (let i: number = 0; i < this._items.length; i++) {
+            // If item does not match predicate then remove it.
+            if (!predicate(this._items[i])) {
+                if (this._currentIndex >= i) {
+                    this._currentIndex--;
+                }
+                this._items.splice(i, 1);
+                i--;
+            }
+        }
     }
 }

--- a/tests/unit/utils/history.test.ts
+++ b/tests/unit/utils/history.test.ts
@@ -114,3 +114,61 @@ test("clearWipesAllHistory", () => {
     history.clear();
     expect(history.current).toBe(undefined);
 });
+
+test("prunePastPreservesCorrectCurrent", () => {
+    const history = Utils.History.createHistoryStack<number>(3);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+
+    expect(history.current).toBe(3);
+
+    // Prune 1 and 2 from the history.
+    history.prune(n => n > 2);
+
+    expect(history.current).toBe(3);
+    expect(history.hasUndo).toBe(false);
+});
+
+test("pruneFuturePreservesCorrectCurrent", () => {
+    const history = Utils.History.createHistoryStack<number>(3);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    history.undo();
+    history.undo();
+
+    expect(history.current).toBe(1);
+
+    // Prune 2 and 3 from the history.
+    history.prune(n => n === 1);
+
+    expect(history.current).toBe(1);
+    expect(history.hasRedo).toBe(false);
+});
+
+test("prunePastAndFuturePreservesCorrectCurrent", () => {
+    const history = Utils.History.createHistoryStack<number>(5);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+    history.push(4);
+    history.push(5);
+    history.undo();
+    history.undo();
+
+    expect(history.current).toBe(3);
+
+    // Prune 1 and 5 from the history.
+    history.prune(n => n !== 1 && n !== 5);
+
+    expect(history.current).toBe(3);
+    expect(history.hasUndo).toBe(true);
+    expect(history.hasRedo).toBe(true);
+});

--- a/tests/unit/utils/history.test.ts
+++ b/tests/unit/utils/history.test.ts
@@ -172,3 +172,21 @@ test("prunePastAndFuturePreservesCorrectCurrent", () => {
     expect(history.hasUndo).toBe(true);
     expect(history.hasRedo).toBe(true);
 });
+
+test("mapTransformsAllElements", () => {
+    const history = Utils.History.createHistoryStack<number>(3);
+    expect(history.current).toBe(undefined);
+
+    history.push(1);
+    history.push(2);
+    history.push(3);
+
+    // Add 10 to all items.
+    history.map(n => n + 10);
+
+    expect(history.current).toBe(13);
+    history.undo();
+    expect(history.current).toBe(12);
+    history.undo();
+    expect(history.current).toBe(11);
+});


### PR DESCRIPTION
Current behaviour is wiping the entire state (and undo stack) when loading a new scheme. This is very annoying when you are making many changes to the scheme. The new behaviour will prune the undo stack of states that are not valid according to the new scheme but will preserve ones that are.