### PR TITLE
Feature/share

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ to `bastian.tech/typedtree-editor/refs/heads/master/`
 ### Dependencies
 * [FileSaver](https://github.com/eligrey/FileSaver.js): Library for saving files that works
 consistently in almost all browsers.
+* [lz-string](https://github.com/pieroxy/lz-string): Library for compressing text.
 
 ## Troubleshooting
 * If `verify-tooling.sh` fails try removing the `./node_modules` directory.

--- a/assets/index.html
+++ b/assets/index.html
@@ -18,14 +18,17 @@
   <!-- Link to the source-code -->
   <a href="https://github.com/BastianBlokland/typedtree-editor" id=github-button>GitHub</a>
 
+  <!-- Button to copy sharable link to clipboard -->
+  <button type="button" class="control-element" id="share-button">Share 📋</button>
+
   <!-- Button to toggle the toolbox -->
-  <button type="button" class="bottomcontrol-element" id="toolbox-toggle">Toolbox (t)</button>
+  <button type="button" class="control-element" id="toolbox-toggle">Toolbox (t)</button>
 
   <!-- Button to focus the view -->
-  <button type="button" class="bottomcontrol-element" id="focus-button">Focus (f)</button>
+  <button type="button" class="control-element" id="focus-button">Focus (f)</button>
 
   <!-- Zoom controls -->
-  <div class="bottomcontrol-element" id="zoomcontrols-container">
+  <div class="control-element" id="zoomcontrols-container">
     Zoom
     <button type="button" id="zoomout-button">Out (-)</button>
     <button type="button" id="zoomin-button">In (+)</button>
@@ -34,8 +37,8 @@
   </div>
 
   <!-- Buttons for undo / redo -->
-  <button type="button" class="bottomcontrol-element" id="undo-button">Undo (z)</button>
-  <button type="button" class="bottomcontrol-element" id="redo-button">Redo (shift-z)</button>
+  <button type="button" class="control-element" id="undo-button">Undo (z)</button>
+  <button type="button" class="control-element" id="redo-button">Redo (shift-z)</button>
 
   <!-- Toolbox containing the main ways to interact with the app -->
   <div id="toolbox">

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 9;
+const version = 10;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/assets/style.css
+++ b/assets/style.css
@@ -36,7 +36,15 @@ html, html > body {
     text-decoration: none;
 }
 
-body .bottomcontrol-element {
+#share-button {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    width: 80px;
+    height: 25px;
+}
+
+body .control-element {
     font-size: 12px;
     border-radius: 8px;
     border: 4px solid #000;
@@ -44,6 +52,7 @@ body .bottomcontrol-element {
     color: #FFF;
     font-weight: bold;
     text-align: center;
+    line-height: 15px;
     padding: 1px 7px 2px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,6 +531,12 @@
         "@types/puppeteer": "*"
       }
     },
+    "@types/lz-string": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.33.tgz",
+      "integrity": "sha512-yWj3OnlKlwNpq9+Jh/nJkVAD3ta8Abk2kIRpjWpVkDlAD43tn6Q6xk5hurp84ndcq54jBDBGCD/WcIR0pspG0A==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
@@ -4705,6 +4711,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
     },
     "magic-string": {
       "version": "0.25.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "file-saver": "^2.0.1",
+    "lz-string": "^1.4.4",
     "normalize-wheel": "^1.0.1"
   },
   "devDependencies": {
@@ -24,6 +25,7 @@
     "@types/file-saver": "^2.0.0",
     "@types/jest": "^24.0.12",
     "@types/jest-environment-puppeteer": "^4.0.0",
+    "@types/lz-string": "^1.3.33",
     "@types/puppeteer": "^1.12.4",
     "codecov": "^3.3.0",
     "css-combine": "^1.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,14 @@ export default {
     },
     plugins: [
         nodeResolve(),
-        commonjs()
+        commonjs({
+            namedExports: {
+                'node_modules/lz-string/libs/lz-string.js': [
+                    'compressToEncodedURIComponent',
+                    'decompressFromEncodedURIComponent'
+                ]
+            }
+        })
     ],
     onwarn(warning, warn) {
         if (warning.code === 'THIS_IS_UNDEFINED')

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import * as TreeScheme from "./treescheme";
 import * as Utils from "./utils";
 
 /** Function to run the main app logic in. */
-export async function run(): Promise<void> {
+export async function run(searchParams: URLSearchParams): Promise<void> {
     window.ondragenter = onDrag;
     window.ondragover = onDrag;
     window.ondragleave = onDrag;

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ export async function run(): Promise<void> {
     if (zoomspeed !== null) {
         setZoomSpeed(parseFloat(zoomspeed));
     }
+    Utils.Dom.subscribeToClick("share-button", enqueueShareToClipboard);
     Utils.Dom.subscribeToClick("toolbox-toggle", toggleToolbox);
     Utils.Dom.subscribeToClick("focus-button", focusTree);
     Utils.Dom.subscribeToClick("zoomin-button", () => { Display.Tree.zoom(0.1); });
@@ -185,6 +186,35 @@ function enqueueCopyTreeToClipboard(): void {
             } catch (e) {
                 alert(`Unable to copy: ${e}`);
             }
+        }
+    });
+}
+
+function enqueueShareToClipboard(): void {
+    sequencer.enqueue(async () => {
+        let url = location.origin + location.pathname;
+        if (url.endsWith("/")) {
+            url = `${url}index.html`;
+        } else if (!url.endsWith("index.html")) {
+            url = `${url}/index.html`;
+        }
+
+        if (currentScheme !== undefined) {
+            const schemeJson = TreeScheme.Serializer.composeJson(currentScheme, false);
+            const schemeUriComp = Utils.Compressor.compressToUriComponent(schemeJson);
+            url = `${url}?scheme=${schemeUriComp}`;
+
+            if (treeHistory.current !== undefined) {
+                const treeJson = Tree.Serializer.composeJson(treeHistory.current, false);
+                const treeUriComp = Utils.Compressor.compressToUriComponent(treeJson);
+                url = `${url}&tree=${treeUriComp}`;
+            }
+        }
+
+        try {
+            await Utils.Dom.writeClipboardText(url);
+        } catch (e) {
+            alert(`Unable to share: ${e}`);
         }
     });
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -192,27 +192,22 @@ function enqueueCopyTreeToClipboard(): void {
 
 function enqueueShareToClipboard(): void {
     sequencer.enqueue(async () => {
-        let url = location.origin + location.pathname;
-        if (url.endsWith("/")) {
-            url = `${url}index.html`;
-        } else if (!url.endsWith("index.html")) {
-            url = `${url}/index.html`;
-        }
+        const url = new URL("index.html", location.origin + location.pathname);
 
         if (currentScheme !== undefined) {
             const schemeJson = TreeScheme.Serializer.composeJson(currentScheme, false);
             const schemeUriComp = Utils.Compressor.compressToUriComponent(schemeJson);
-            url = `${url}?scheme=${schemeUriComp}`;
+            url.searchParams.append("scheme", schemeUriComp);
 
             if (treeHistory.current !== undefined) {
                 const treeJson = Tree.Serializer.composeJson(treeHistory.current, false);
                 const treeUriComp = Utils.Compressor.compressToUriComponent(treeJson);
-                url = `${url}&tree=${treeUriComp}`;
+                url.searchParams.append("tree", treeUriComp);
             }
         }
 
         try {
-            await Utils.Dom.writeClipboardText(url);
+            await Utils.Dom.writeClipboardText(url.href);
         } catch (e) {
             alert(`Unable to share: ${e}`);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,5 +24,10 @@ Display.TreeScheme.initialize();
 (window as any).getCurrentSchemeJson = App.getCurrentSchemeJson;
 (window as any).getCurrentTreeJson = App.getCurrentTreeJson;
 
+// Parse the search-params from the url and cleanup browser url.
+const url = new URL(location.href);
+const searchParams = url.searchParams;
+history.replaceState("", "", url.origin + url.pathname.replace("index.html", ""));
+
 // Starting running the app.
-App.run();
+App.run(searchParams);

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ Display.TreeScheme.initialize();
 // Export functions to window for interop.
 (window as any).getCurrentSchemeJson = App.getCurrentSchemeJson;
 (window as any).getCurrentTreeJson = App.getCurrentTreeJson;
+(window as any).getShareUrl = App.getShareUrl;
 
 // Parse the search-params from the url and cleanup browser url.
 const url = new URL(location.href);

--- a/src/tree/serializer.ts
+++ b/src/tree/serializer.ts
@@ -8,15 +8,16 @@ import * as Tree from "./tree";
 /**
  * Compose json for the given node (and its children).
  * @param node Node to create json for.
+ * @param prettyFormat Should the output be pretty formatted.
  * @returns Json representing the given node.
  */
-export function composeJson(node: Tree.INode): string {
+export function composeJson(node: Tree.INode, prettyFormat: boolean = true): string {
     if (node.type === Tree.noneNodeType) {
         return "";
     }
 
     const obj = createObject(node);
-    return JSON.stringify(obj, undefined, 2);
+    return JSON.stringify(obj, undefined, prettyFormat ? 2 : 0);
 }
 
 function createObject(node: Tree.INode): object {

--- a/src/treescheme/serializer.ts
+++ b/src/treescheme/serializer.ts
@@ -7,11 +7,12 @@ import * as TreeScheme from "./treescheme";
 /**
  * Compose json for the scheme.
  * @param scheme Scheme to create json for.
+ * @param prettyFormat Should the output be pretty formatted.
  * @returns Json representing the given scheme.
  */
-export function composeJson(scheme: TreeScheme.IScheme): string {
+export function composeJson(scheme: TreeScheme.IScheme, prettyFormat: boolean = true): string {
     const obj = createSchemeObject(scheme);
-    return JSON.stringify(obj, undefined, 2);
+    return JSON.stringify(obj, undefined, prettyFormat ? 2 : 0);
 }
 
 function createSchemeObject(scheme: TreeScheme.IScheme): object {

--- a/src/utils/compressor.ts
+++ b/src/utils/compressor.ts
@@ -1,0 +1,23 @@
+/**
+ * @file Utilities for compressing text.
+ */
+
+import * as LZString from "lz-string";
+
+/**
+ * Compresses given text into uri-safe ascii text.
+ * @param uncompressed Text to compress.
+ * @returns Compressed uri-safe ascii text.
+ */
+export function compressToUriComponent(uncompressed: string): string {
+    return LZString.compressToEncodedURIComponent(uncompressed);
+}
+
+/**
+ * Decompress text that was previously compressed using 'compressToUriComponent'.
+ * @param compressed Text that was compressed using 'compressToUriComponent'.
+ * @returns Original uncompressed text.
+ */
+export function decompressFromUriComponent(compressed: string): string {
+    return LZString.decompressFromEncodedURIComponent(compressed);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@
  * @file Module containing utilities.
  */
 
+import * as Compressor from "./compressor";
 import * as Dom from "./dom";
 import * as History from "./history";
 import * as Parser from "./parser";
@@ -9,4 +10,4 @@ import * as Sequencer from "./sequencer";
 import * as Vector from "./vector";
 
 export * from "./misc";
-export { Dom, History, Parser, Sequencer, Vector };
+export { Compressor, Dom, History, Parser, Sequencer, Vector };

--- a/tests/unit/utils/compressor.test.ts
+++ b/tests/unit/utils/compressor.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Jest tests for utils/compressor.ts
+ */
+
+import * as Utils from "../../../src/utils";
+
+test("compressToUriComponentProducesUriSaveText", () => {
+    const compressed = Utils.Compressor.compressToUriComponent("This is a test string");
+    expect(compressed).toEqual(encodeURIComponent(compressed));
+});
+
+test("compressToUriComponentCanBeDecompressed", () => {
+    const input = "This is a test string";
+    const compressed = Utils.Compressor.compressToUriComponent(input);
+    const decompressed = Utils.Compressor.decompressFromUriComponent(compressed);
+    expect(decompressed).toEqual(input);
+});


### PR DESCRIPTION
Adds a feature to be able to share the currently loaded scheme and tree as a url. 

It works by serialising the loaded scheme and tree as json and them compressing them using the [lz-string](https://github.com/pieroxy/lz-string) library. After compressing them they are encoded into a url as search-parameters. 

*Note: This can produce very large url's but Chrome, Firefox and Safari seem to be able to handle them so far*

When the page load it check the search-parameters and decompresses and loads the scheme and tree.