### PR TITLE
Integration mode

### DIFF
--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 16;
+const version = 18;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,20 @@ if (location.protocol !== "https:" && !location.host.startsWith("127.0.0.1")) {
     (window as any).getCurrentTreeJson = App.getCurrentTreeJson;
     (window as any).getCurrentPackJson = App.getCurrentPackJson;
     (window as any).getShareUrl = App.getShareUrl;
+    (window as any).enqueueLoadScheme = App.enqueueLoadScheme;
+    (window as any).enqueueLoadSchemeFromUrlOrFile = App.enqueueLoadSchemeFromUrlOrFile;
+    (window as any).enqueueEnsureTree = App.enqueueEnsureTree;
+    (window as any).enqueueNewTree = App.enqueueNewTree;
+    (window as any).enqueueLoadTree = App.enqueueLoadTree;
+    (window as any).enqueueLoadTreeFromUrlOrFile = App.enqueueLoadTreeFromUrlOrFile;
+    (window as any).enqueueExportScheme = App.enqueueExportScheme;
+    (window as any).enqueueExportTree = App.enqueueExportTree;
+    (window as any).enqueueExportPack = App.enqueueExportPack;
+    (window as any).enqueueCopyTreeToClipboard = App.enqueueCopyTreeToClipboard;
+    (window as any).enqueuePasteTree = App.enqueuePasteTree;
+    (window as any).enqueueShareToClipboard = App.enqueueShareToClipboard;
+    (window as any).enqueueUndo = App.enqueueUndo;
+    (window as any).enqueueRedo = App.enqueueRedo;
 
     // Parse the search-params from the url and cleanup browser url.
     const url = new URL(location.href);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -279,7 +279,7 @@ export function clearChildren(element: Element): void {
 
 /**
  * Set the text content of an element.
- * * Will throw if the element doesn't exist.
+ * Will throw if the element doesn't exist.
  * @param elementId Id of the element to set the text for.
  * @param text Text to assign to the element.
  */
@@ -289,6 +289,19 @@ export function setText(elementId: string, text: string): void {
         throw new Error(`Element with id: ${elementId} not found`);
     }
     element.textContent = text;
+}
+
+/**
+ * Hide an element be setting the style visibility to 'hidden'.
+ * Will throw if the element doesn't exist.
+ * @param elementId Id of the element to hide.
+ */
+export function hideElementById(elementId: string): void {
+    const elem = document.getElementById(elementId);
+    if (elem === null) {
+        throw new Error(`Element with id: ${elementId} not found`);
+    }
+    elem.style.visibility = "hidden";
 }
 
 /**


### PR DESCRIPTION
Adds a special 'integration' mode that can be enable passing passing the url param `mode=integration`. When this mode is active the on-page controls from loading and saving are disabled and the app expects to be controlled by external code (using the functions exported on the window object).

Useful for integrating in a electron wrapper for example.