### PR TITLE
Fix node layout bugs

### DIFF
--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -1,17 +1,17 @@
 #svg-display .node-background {
     fill: #999;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 4;
+    stroke-width: 4px;
 }
 
 #svg-display .nonenode-background {
     fill: #555;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 4;
+    stroke-width: 4px;
 }
 
 #svg-display .node-type {
@@ -49,34 +49,34 @@
 /* Field backgrounds */
 #svg-display .string-value-background, #svg-display .stringArray-value-background {
     fill: #696;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 2;
+    stroke-width: 2px;
 }
 
 #svg-display .number-value-background, #svg-display .numberArray-value-background {
     fill: #669;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 2;
+    stroke-width: 2px;
 }
 
 #svg-display .boolean-value-background, #svg-display .booleanArray-value-background {
     fill: #966;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 2;
+    stroke-width: 2px;
 }
 
 #svg-display .node-value-background, #svg-display .nodeArray-value-background {
     fill: #999966;
-    rx: 10;
-    ry: 10;
+    rx: 10px;
+    ry: 10px;
     stroke: #000;
-    stroke-width: 2;
+    stroke-width: 2px;
 }
 
 #svg-display .fieldname {

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -86,6 +86,7 @@
     font-weight: bold;
     white-space: pre;
     pointer-events: none;
+    vertical-align: sub;
 }
 
 /* Field values */

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -1,25 +1,28 @@
 #svg-display .node-background {
     fill: #999;
-    rx: 10px;
-    ry: 10px;
+    rx: 8px;
+    ry: 8px;
     stroke: #000;
-    stroke-width: 4px;
+    stroke-width: 2px;
 }
 
 #svg-display .nonenode-background {
     fill: #555;
-    rx: 10px;
-    ry: 10px;
+    rx: 8px;
+    ry: 8px;
     stroke: #000;
-    stroke-width: 4px;
+    stroke-width: 2px;
 }
 
 #svg-display .node-type {
     font-weight: bold;
-    margin-left: 5%;
     font-size: 10px;
-    width: 90%;
-    height: 90%;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
     background-color: #DDD;
     cursor: pointer;
 }
@@ -49,32 +52,32 @@
 /* Field backgrounds */
 #svg-display .string-value-background, #svg-display .stringArray-value-background {
     fill: #696;
-    rx: 10px;
-    ry: 10px;
+    rx: 5px;
+    ry: 5px;
     stroke: #000;
     stroke-width: 2px;
 }
 
 #svg-display .number-value-background, #svg-display .numberArray-value-background {
     fill: #669;
-    rx: 10px;
-    ry: 10px;
+    rx: 5px;
+    ry: 5px;
     stroke: #000;
     stroke-width: 2px;
 }
 
 #svg-display .boolean-value-background, #svg-display .booleanArray-value-background {
     fill: #966;
-    rx: 10px;
-    ry: 10px;
+    rx: 5px;
+    ry: 5px;
     stroke: #000;
     stroke-width: 2px;
 }
 
 #svg-display .node-value-background, #svg-display .nodeArray-value-background {
     fill: #999966;
-    rx: 10px;
-    ry: 10px;
+    rx: 5px;
+    ry: 5px;
     stroke: #000;
     stroke-width: 2px;
 }
@@ -88,22 +91,42 @@
 /* Field values */
 #svg-display .string-value {
     background-color: #DDD;
-    width: 90%;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
 }
 
 #svg-display .number-value {
     background-color: #DDD;
-    width: 90%;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
 }
 
 #svg-display .enum-value {
     background-color: #DDD;
-    width: 90%;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
 }
 
 #svg-display .boolean-value {
     background-color: #DDD;
     cursor: pointer;
+    display: block;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
 }
 
 #svg-display .connection {

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 23;
+const version = 24;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 24;
+const version = 26;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/assets/style.css
+++ b/assets/style.css
@@ -4,7 +4,7 @@
 html, html > body {
     width: 100%;
     height: 100%;
-    margin: 0;
+    margin: 0px;
     overflow: hidden;
     background-color: #444;
 }

--- a/src/display/svg.ts
+++ b/src/display/svg.ts
@@ -447,8 +447,7 @@ class GroupElement implements IElement {
     private addForeignObject(position: Vector.Position, size: Vector.Size, htmlElement: HTMLElement): void {
         const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
         foreignObject.setAttribute("x", position.x.toString());
-        // + 3 here because the foreign objects seem to render too low on most browsers.
-        foreignObject.setAttribute("y", (position.y - Utils.half(size.y) + 2).toString());
+        foreignObject.setAttribute("y", position.y.toString());
         foreignObject.setAttribute("width", size.x.toString());
         foreignObject.setAttribute("height", size.y.toString());
         foreignObject.appendChild(htmlElement);


### PR DESCRIPTION
We used to depend on the chromium element styling for the node layout to be correct, this made the alignment on Firefox pretty bad. This pr fixes most of that.

Firefox layout:
![image](https://user-images.githubusercontent.com/14230060/191837189-a1ab25c3-1d50-46ba-8f71-26fbd8cb9667.png)

Chromium layout:
![image](https://user-images.githubusercontent.com/14230060/191837582-39761517-e655-42ac-ad3f-641e5e18eb06.png)
