### PR TITLE
Named nodes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Tiny electron wrapper to ease in saving until
         }
       ]
     }
-  ]
+  ],
+  "featureNodeNames": true
 }
 ```
 Elements in the scheme:
@@ -103,6 +104,7 @@ and show it as a dropdown in the ui.
 ```json
 {
   "$type": "AI.Items.Selector",
+  "$name": "My selector",
   "children": [
     {
       "$type": "AI.Conditions.OutOfHealth",
@@ -111,8 +113,9 @@ and show it as a dropdown in the ui.
   ]
 }
 ```
-Format is plain json with the exception of the `$type` property which indicates from which type in
-the scheme this node was created from.
+Format is plain json with some well-known fields:
+- `$type`: Indicates the node-type in the scheme this node was created from.
+- `$name`: Optional name for the node.
 
 ### Example of the tree-pack format
 ```json
@@ -125,7 +128,7 @@ TreePack is a single file containing both a scheme and a tree, can be useful for
 
 ## Project setup
 This project is written in [TypeScript](https://github.com/Microsoft/TypeScript) and is transpiled
-into es5 JavaScript. Tree is rendered with a combination of plain html and svg.
+into es6 JavaScript. Tree is rendered with a combination of plain html and svg.
 
 For dependency management [Npm](https://github.com/npm/cli) is used.
 [Rollup](https://github.com/rollup/rollup) is used for creating the output bundle, and deployments

--- a/assets/example.treescheme.json
+++ b/assets/example.treescheme.json
@@ -203,5 +203,6 @@
         }
       ]
     }
-  ]
+  ],
+  "featureNodeNames": true
 }

--- a/assets/index.html
+++ b/assets/index.html
@@ -118,5 +118,10 @@
       <path d="M 0 4.5 L 0 -1 z" fill="none" stroke="#000" stroke-width="2" />
     </g>
 
+    <g id="name">
+      <circle cx="0" cy="0" r="7" fill="#DDD" stroke="#000" />
+      <path d="M -2 -3.5 L -2 3.5 M 2 -3.5 L 2 3.5 M -2 -3.5 L 2 3.5 z" fill="none" stroke="#000" stroke-width="1" />
+    </g>
+
   </defs>
 </svg>

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -50,6 +50,17 @@
 }
 
 /* Node name */
+#svg-display .node-name {
+    background: none;
+    display: block;
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
+}
+
 #svg-display .node-name-button {
     cursor: pointer;
 }

--- a/assets/nodestyle.css
+++ b/assets/nodestyle.css
@@ -49,6 +49,11 @@
     stroke-width: 2px;
 }
 
+/* Node name */
+#svg-display .node-name-button {
+    cursor: pointer;
+}
+
 /* Field backgrounds */
 #svg-display .string-value-background, #svg-display .stringArray-value-background {
     fill: #696;

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 27;
+const version = 28;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/assets/serviceworker.js
+++ b/assets/serviceworker.js
@@ -3,7 +3,7 @@
  * by serving files from the cache.
  */
 
-const version = 26;
+const version = 27;
 const cacheName = `${version}-offline`;
 const preCachedFiles = [
     "index.html",

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -114,8 +114,13 @@ function createNode(
         toolTipElement.addText("node-tooltip-text", definition.comment, { x: 0, y: 0 }, nodeTooltipSize);
     }
 
-    nodeElement.addGraphics("node-name-button", "name",
-        { x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize), y: halfNodeHeaderHeight });
+    const nodeNameButtonSize: Vector.IVector2 = {
+        x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize),
+        y: halfNodeHeaderHeight,
+    };
+    nodeElement.addGraphics("node-name-button", "name", nodeNameButtonSize, () => {
+        changed(Tree.Modifications.nodeWithName(node, node.name === undefined ? "Unnamed" : undefined));
+    });
 }
 
 type fieldChangedCallback<T extends Tree.Field> = (newField: T) => void;

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -84,6 +84,7 @@ function createNode(
     const size = positionLookup.getSize(node);
     const nodeElement = builder.addElement("node", positionLookup.getPosition(node));
     const backgroundClass = node.type === Tree.noneNodeType ? "nonenode-background" : "node-background";
+    const allowName = node.type !== Tree.noneNodeType;
 
     // Add background.
     nodeElement.addRect(backgroundClass, size, Vector.zeroVector);
@@ -123,13 +124,15 @@ function createNode(
     }
 
     // Add name toggle button.
-    const nodeNameButtonSize: Vector.IVector2 = {
-        x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize),
-        y: halfNodeHeaderHeight + yOffset,
-    };
-    nodeElement.addGraphics("node-name-button", "name", nodeNameButtonSize, () => {
-        changed(Tree.Modifications.nodeWithName(node, node.name === undefined ? "Unnamed" : undefined));
-    });
+    if (allowName) {
+        const nodeNameButtonSize: Vector.IVector2 = {
+            x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize),
+            y: halfNodeHeaderHeight + yOffset,
+        };
+        nodeElement.addGraphics("node-name-button", "name", nodeNameButtonSize, () => {
+            changed(Tree.Modifications.nodeWithName(node, node.name === undefined ? "Unnamed" : undefined));
+        });
+    }
 
     yOffset += nodeHeaderHeight;
 

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -101,9 +101,11 @@ function createNode(
         yOffset += nodeNameHeight;
     }
 
+    const headerYOffset = yOffset;
+
     // Add type dropdown.
     nodeElement.addDropdown("node-type", typeOptionsIndex, typeOptions,
-        { x: infoButtonSize + Utils.half(nodeContentPadding), y: Utils.half(nodeContentPadding) + yOffset },
+        { x: infoButtonSize + Utils.half(nodeContentPadding), y: Utils.half(nodeContentPadding) + headerYOffset },
         { x: size.x - nodeContentPadding - infoButtonSize - nameButtonSize, y: nodeHeaderHeight - nodeContentPadding },
         newIndex => {
             const newNodeType = typeOptions[newIndex];
@@ -111,24 +113,11 @@ function createNode(
             changed(newNode);
         });
 
-    // Add tooltip.
-    if (definition !== undefined && definition.comment !== undefined) {
-        const infoElement = nodeElement.addElement("node-info", Vector.zeroVector);
-        infoElement.addGraphics("node-info-button", "info", {
-            x: Utils.half(nodeContentPadding) + Utils.half(infoButtonSize),
-            y: halfNodeHeaderHeight + yOffset
-        });
-
-        const toolTipElement = infoElement.addElement("node-tooltip", { x: 25, y: -25 });
-        toolTipElement.addRect("node-tooltip-background", nodeTooltipSize, Vector.zeroVector);
-        toolTipElement.addText("node-tooltip-text", definition.comment, { x: 0, y: 0 }, nodeTooltipSize);
-    }
-
     // Add name toggle button.
     if (allowName) {
         const nodeNameButtonSize: Vector.IVector2 = {
             x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize),
-            y: halfNodeHeaderHeight + yOffset,
+            y: halfNodeHeaderHeight + headerYOffset,
         };
         nodeElement.addGraphics("node-name-button", "name", nodeNameButtonSize, () => {
             changed(Tree.Modifications.nodeWithName(node, node.name === undefined ? "Unnamed" : undefined));
@@ -143,6 +132,19 @@ function createNode(
             changed(Tree.Modifications.nodeWithField(node, newField));
         });
     });
+
+    // Add tooltip.
+    if (definition !== undefined && definition.comment !== undefined) {
+        const infoElement = nodeElement.addElement("node-info", Vector.zeroVector);
+        infoElement.addGraphics("node-info-button", "info", {
+            x: Utils.half(nodeContentPadding) + Utils.half(infoButtonSize),
+            y: halfNodeHeaderHeight + headerYOffset
+        });
+
+        const toolTipElement = infoElement.addElement("node-tooltip", { x: 25, y: -25 });
+        toolTipElement.addRect("node-tooltip-background", nodeTooltipSize, Vector.zeroVector);
+        toolTipElement.addText("node-tooltip-text", definition.comment, { x: 0, y: 0 }, nodeTooltipSize);
+    }
 }
 
 type fieldChangedCallback<T extends Tree.Field> = (newField: T) => void;

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -62,6 +62,7 @@ const nodeInputSlotOffset: Vector.IVector2 = { x: 0, y: 12.5 };
 const nodeTooltipSize: Vector.IVector2 = { x: 450, y: 75 };
 const nodeContentPadding = 6;
 const infoButtonSize = 20;
+const nameButtonSize = 20;
 const nodeConnectionCurviness = .7;
 
 type nodeChangedCallback = (newNode: Tree.INode) => void;
@@ -89,7 +90,7 @@ function createNode(
         typeOptionsIndex,
         typeOptions,
         { x: infoButtonSize + Utils.half(nodeContentPadding), y: Utils.half(nodeContentPadding) },
-        { x: size.x - nodeContentPadding - infoButtonSize, y: nodeHeaderHeight - nodeContentPadding },
+        { x: size.x - nodeContentPadding - infoButtonSize - nameButtonSize, y: nodeHeaderHeight - nodeContentPadding },
         newIndex => {
             const newNodeType = typeOptions[newIndex];
             const newNode = TreeScheme.Instantiator.changeNodeType(typeLookup.scheme, node, newNodeType);
@@ -112,6 +113,9 @@ function createNode(
         toolTipElement.addRect("node-tooltip-background", nodeTooltipSize, Vector.zeroVector);
         toolTipElement.addText("node-tooltip-text", definition.comment, { x: 0, y: 0 }, nodeTooltipSize);
     }
+
+    nodeElement.addGraphics("node-name-button", "name",
+        { x: size.x - Utils.half(nodeContentPadding) - Utils.half(nameButtonSize), y: halfNodeHeaderHeight });
 }
 
 type fieldChangedCallback<T extends Tree.Field> = (newField: T) => void;

--- a/src/display/tree.ts
+++ b/src/display/tree.ts
@@ -32,7 +32,7 @@ export function setTree(
 
     Svg.setContent(b => {
         positionLookup.nodes.forEach(node => {
-            createNode(b, node, typeLookup, positionLookup, newNode => {
+            createNode(b, node, typeLookup, positionLookup, scheme.features, newNode => {
                 if (changed !== undefined) {
                     changed(Tree.Modifications.treeWithReplacedNode(root, node, newNode));
                 }
@@ -73,6 +73,7 @@ function createNode(
     node: Tree.INode,
     typeLookup: TreeScheme.TypeLookup.ITypeLookup,
     positionLookup: Tree.PositionLookup.IPositionLookup,
+    supportedFeatures: TreeScheme.Features,
     changed: nodeChangedCallback): void {
 
     let definition: TreeScheme.INodeDefinition | undefined;
@@ -84,7 +85,7 @@ function createNode(
     const size = positionLookup.getSize(node);
     const nodeElement = builder.addElement("node", positionLookup.getPosition(node));
     const backgroundClass = node.type === Tree.noneNodeType ? "nonenode-background" : "node-background";
-    const allowName = node.type !== Tree.noneNodeType;
+    const allowName = node.type !== Tree.noneNodeType && (supportedFeatures & TreeScheme.Features.NodeNames) !== 0;
 
     // Add background.
     nodeElement.addRect(backgroundClass, size, Vector.zeroVector);

--- a/src/tree/modifications.ts
+++ b/src/tree/modifications.ts
@@ -58,6 +58,9 @@ export function fieldWithValue<T extends Tree.Field>(field: T, value: Tree.Field
  */
 export function nodeWithField(node: Tree.INode, field: Tree.Field): Tree.INode {
     return Tree.createNode(node.type, b => {
+        if (node.name !== undefined) {
+            b.pushName(node.name);
+        }
         node.fields.forEach(orgField => {
             if (orgField.name === field.name) {
                 b.pushField(field);

--- a/src/tree/modifications.ts
+++ b/src/tree/modifications.ts
@@ -98,6 +98,9 @@ function fieldWithNewNode(origin: Tree.INode, output: Tree.IFieldElementIdentifi
  */
 export function cloneNode(node: Tree.INode): Tree.INode {
     return Tree.createNode(node.type, b => {
+        if (node.name !== undefined) {
+            b.pushName(node.name);
+        }
         node.fields.forEach(orgField => b.pushField(cloneField(orgField)));
     });
 }

--- a/src/tree/modifications.ts
+++ b/src/tree/modifications.ts
@@ -69,6 +69,21 @@ export function nodeWithField(node: Tree.INode, field: Tree.Field): Tree.INode {
 }
 
 /**
+ * Create a new node with a new name.
+ * @param node Original node.
+ * @param name New name.
+ * @returns New node with updated name.
+ */
+export function nodeWithName(node: Tree.INode, name: string | undefined): Tree.INode {
+    return Tree.createNode(node.type, b => {
+        if (name !== undefined) {
+            b.pushName(name);
+        }
+        node.fields.forEach(orgField => b.pushField(orgField));
+    });
+}
+
+/**
  * Create a new tree based on a existing tree but with a single node replaced with another.
  * @param root Root of the tree to replace.
  * @param target Node to replace.

--- a/src/tree/modifications.ts
+++ b/src/tree/modifications.ts
@@ -34,7 +34,8 @@ export function fieldWithElement<T extends Tree.Field>(
     }
 
     // If the field is not an array then treat it as a value.
-    // Needs ugly cast to 'unknown' as the typescript compiler cannot figure out that these types    // have overlap.
+    // Needs ugly cast to 'unknown' as the typescript compiler cannot figure out that these types
+    // have overlap.
     return fieldWithValue(field, element as unknown as Tree.FieldValueType<T>);
 }
 

--- a/src/tree/parser.ts
+++ b/src/tree/parser.ts
@@ -68,9 +68,17 @@ function parseNode(obj: any): Tree.INode {
         }
     }
 
+    let name: any = obj.$name;
+    if (name === undefined || name === null || typeof name !== "string" || name === "") {
+        name = undefined;
+    }
+
     return Tree.createNode(type, b => {
+        if (name !== undefined) {
+            b.pushName(name);
+        }
         Object.keys(obj).forEach(key => {
-            if (key !== "$type") {
+            if (!key.startsWith("$")) {
                 const field = parseField(key, obj[key]);
                 if (field !== undefined) {
                     b.pushField(field);

--- a/src/tree/positionlookup.ts
+++ b/src/tree/positionlookup.ts
@@ -9,6 +9,9 @@ import * as Utils from "../utils";
 import { Vector } from "../utils";
 import * as Tree from "./tree";
 
+/** Height of the name area of a node. */
+export const nodeNameHeight = 25;
+
 /** Height for the header (the part that contains the type) of a node. */
 export const nodeHeaderHeight = 25;
 
@@ -78,7 +81,11 @@ export function createPositionLookup(root: Tree.INode): IPositionLookup {
  * @returns Number representing the height of the given node.
  */
 export function getNodeHeight(node: Tree.INode): number {
-    return nodeHeaderHeight + node.fields.map(getFieldHeight).reduce(Utils.add, 0);
+    let height = 0;
+    height += node.name !== undefined ? nodeNameHeight : 0;
+    height += nodeHeaderHeight;
+    height += node.fields.map(getFieldHeight).reduce(Utils.add, 0);
+    return height;
 }
 
 /**

--- a/src/tree/serializer.ts
+++ b/src/tree/serializer.ts
@@ -34,6 +34,9 @@ export function createObject(node: Tree.INode): object {
     if (node.type !== Tree.anonymousNodeType) {
         obj.$type = node.type;
     }
+    if (node.name !== undefined && node.name !== "") {
+        obj.$name = node.name;
+    }
     node.fields.forEach(field => {
         switch (field.kind) {
             case "string":

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -66,6 +66,7 @@ export type Field =
 /** Immutable structure representing a single node in the tree. */
 export interface INode {
     readonly type: NodeType;
+    readonly name?: string;
     readonly fields: ReadonlyArray<Field>;
     readonly fieldNames: ReadonlyArray<string>;
 
@@ -139,6 +140,7 @@ export interface INodeBuilder {
     pushBooleanArrayField(name: string, value: ReadonlyArray<boolean>): boolean;
     pushNodeArrayField(name: string, value: ReadonlyArray<INode>): boolean;
     pushField(field: Field): boolean;
+    pushName(name: string): void;
 }
 
 /**
@@ -270,6 +272,11 @@ export function printNode(node: INode, indent: number = 0, printLine: (line: str
     // Print type
     printLine(`Type: ${node.type}`, indent);
 
+    // Print name
+    if(node.name !== undefined) {
+        printLine(`Name: ${node.name}`, indent);
+    }
+
     // Print fields
     node.fields.forEach(field => {
         switch (field.kind) {
@@ -304,8 +311,9 @@ export function printNode(node: INode, indent: number = 0, printLine: (line: str
 class NodeImpl implements INode {
     private readonly _type: NodeType;
     private readonly _fields: ReadonlyArray<Field>;
+    private readonly _name?: string;
 
-    constructor(type: NodeType, fields: ReadonlyArray<Field>) {
+    constructor(type: NodeType, fields: ReadonlyArray<Field>, name?: string) {
         if (type === "") {
             throw new Error("Node must has a type");
         }
@@ -318,6 +326,7 @@ class NodeImpl implements INode {
 
         this._type = type;
         this._fields = fields;
+        this._name = name;
     }
 
     get type(): NodeType {
@@ -330,6 +339,10 @@ class NodeImpl implements INode {
 
     get fieldNames(): ReadonlyArray<string> {
         return this._fields.map(getFieldName);
+    }
+
+    get name(): string | undefined {
+        return this._name;
     }
 
     public getField(name: string): Field | undefined {
@@ -353,6 +366,7 @@ class NodeImpl implements INode {
 class NodeBuilderImpl implements INodeBuilder {
     private readonly _type: NodeType;
     private _fields: Field[];
+    private _name?: string;
     private _build: boolean;
 
     constructor(type: NodeType) {
@@ -415,8 +429,12 @@ class NodeBuilderImpl implements INodeBuilder {
         return true;
     }
 
+    public pushName(name: string) {
+        this._name = name;
+    }
+
     public build(): INode {
         this._build = true;
-        return new NodeImpl(this._type, this._fields);
+        return new NodeImpl(this._type, this._fields, this._name);
     }
 }

--- a/src/treescheme/instantiator.ts
+++ b/src/treescheme/instantiator.ts
@@ -35,6 +35,10 @@ export function duplicateWithMissingFields(scheme: TreeScheme.IScheme, tree: Tre
             throw new Error(`Unable to find definition for node-type: ${node.type}`);
         }
         return Tree.createNode(definition.nodeType, b => {
+            // Copy the name from the original.
+            if (node.name !== undefined) {
+                b.pushName(node.name);
+            }
             // Copy fields from the original if it has them, otherwise create defaults.
             definition.fields.forEach(f => {
                 const orgField = node.getField(f.name);
@@ -77,6 +81,10 @@ export function changeNodeType(scheme: TreeScheme.IScheme, node: Tree.INode, new
         throw new Error(`New node-type ${newNodeType} cannot be found in the given scheme`);
     }
     return Tree.createNode(newNodeType, b => {
+        // Copy the name from the original.
+        if (node.name !== undefined) {
+            b.pushName(node.name);
+        }
         newNodeDefinition.fields.forEach(f => {
             /* If the field of the original node is compatible then use that, otherwise create a new
             default field. */

--- a/src/treescheme/parser.ts
+++ b/src/treescheme/parser.ts
@@ -65,6 +65,9 @@ function parseScheme(obj: any): TreeScheme.IScheme {
     }
 
     return TreeScheme.createScheme(rootAliasIdentifier, schemeBuilder => {
+        if (Utils.Parser.validateBoolean(obj.featureNodeNames)) {
+            schemeBuilder.allowFeatures(TreeScheme.Features.NodeNames);
+        }
         parseAliases(schemeBuilder, obj);
         parseEnums(schemeBuilder, obj);
         parseNodes(schemeBuilder, obj);

--- a/src/treescheme/serializer.ts
+++ b/src/treescheme/serializer.ts
@@ -26,6 +26,7 @@ export function createObject(scheme: TreeScheme.IScheme): object {
     obj.aliases = scheme.aliases.map(createAliasObject);
     obj.enums = scheme.enums.map(createEnumObject);
     obj.nodes = scheme.nodes.map(createNodeObject);
+    obj.featureNodeNames = TreeScheme.featureSupported(scheme, TreeScheme.Features.NodeNames);
     return obj;
 }
 

--- a/src/treescheme/validator.ts
+++ b/src/treescheme/validator.ts
@@ -37,6 +37,11 @@ export function validateNode(scheme: TreeScheme.IScheme, alias: TreeScheme.IAlia
         return true;
     }
 
+    // Validate that the scheme supports named nodes.
+    if (node.name !== undefined && !TreeScheme.featureSupported(scheme, TreeScheme.Features.NodeNames)) {
+        return createFailure("Named nodes are not supported by the scheme");
+    }
+
     // Validate type.
     if (!alias.containsValue(node.type)) {
         return createInvalidNodeTypeFailure(alias, node.type);

--- a/tests/unit/tree/modifications.test.ts
+++ b/tests/unit/tree/modifications.test.ts
@@ -89,6 +89,7 @@ test("cloneNode", () => {
         b.pushStringField("innerFieldA", "innerValueA");
     });
     const innerNodeB = Tree.createNode("innerNode", b => {
+        b.pushName("Inner Node B");
         b.pushStringField("innerFieldB", "innerValueB");
     });
     const node = Tree.createNode("testNode", b => {

--- a/tests/unit/tree/modifications.test.ts
+++ b/tests/unit/tree/modifications.test.ts
@@ -68,6 +68,20 @@ test("nodeWithField", () => {
         }));
 });
 
+
+test("nodeWithName", () => {
+    const node = Tree.createNode("testNode", b => {
+        b.pushStringField("f1", "v1");
+        b.pushStringField("f2", "v2");
+    });
+    expect(Tree.Modifications.nodeWithName(node, "Hello World"))
+        .toEqual(Tree.createNode("testNode", b => {
+            b.pushName("Hello World");
+            b.pushStringField("f1", "v1");
+            b.pushStringField("f2", "v2");
+        }));
+});
+
 test("treeWithReplacedNode", () => {
     const innerNodeA = Tree.createNode("innerNode", b => {
         b.pushStringField("innerFieldA", "innerValueA");

--- a/tests/unit/tree/modifications.test.ts
+++ b/tests/unit/tree/modifications.test.ts
@@ -58,11 +58,13 @@ test("fieldWithValueNodeArray", () => {
 
 test("nodeWithField", () => {
     const node = Tree.createNode("testNode", b => {
+        b.pushName("Hello World");
         b.pushStringField("f1", "v1");
         b.pushStringField("f2", "v2");
     });
     expect(Tree.Modifications.nodeWithField(node, { kind: "string", name: "f2", value: "v3" }))
         .toEqual(Tree.createNode("testNode", b => {
+            b.pushName("Hello World");
             b.pushStringField("f1", "v1");
             b.pushStringField("f2", "v3");
         }));

--- a/tests/unit/tree/parser.test.ts
+++ b/tests/unit/tree/parser.test.ts
@@ -203,3 +203,42 @@ test("nodeCanBeParsedFromAnObject", () => {
         }));
     }
 });
+
+test("nodeWithName", () => {
+    const json = `{
+        "$type": "test",
+        "$name": "Hello World"
+    }`;
+    const parseResult = Tree.Parser.parseJson(json);
+    expect(parseResult.kind).toBe("success");
+    if (parseResult.kind === "success") {
+        expect(parseResult.value).toEqual(Tree.createNode("test", b => {
+            b.pushName("Hello World");
+        }));
+    }
+});
+
+test("emptyNameIsIgnored", () => {
+    const json = `{
+        "$type": "test",
+        "$name": ""
+    }`;
+    const parseResult = Tree.Parser.parseJson(json);
+    expect(parseResult.kind).toBe("success");
+    if (parseResult.kind === "success") {
+        expect(parseResult.value).toEqual(Tree.createNode("test"));
+    }
+});
+
+test("nullNameIsIgnored", () => {
+    const json = `{
+        "$type": "test",
+        "$name": null
+    }`;
+    const parseResult = Tree.Parser.parseJson(json);
+    expect(parseResult.kind).toBe("success");
+    if (parseResult.kind === "success") {
+        expect(parseResult.value).toEqual(Tree.createNode("test"));
+    }
+});
+

--- a/tests/unit/tree/serializer.test.ts
+++ b/tests/unit/tree/serializer.test.ts
@@ -8,6 +8,7 @@ import * as Utils from "../../../src/utils";
 test("savedJsonIsIdenticalToReadJson", () => {
     const json = Utils.formatJson(`{
         "$type": "root",
+        "$name": "My Root Node",
         "str": "string",
         "num": 42,
         "bool": true,
@@ -79,4 +80,23 @@ test("noneNodesAreFilteredOutOfNodeArrayFields", () => {
 test("noneRootNodeLeadsToEmptyJson", () => {
     const composedJson = Tree.Serializer.composeJson(Tree.createNoneNode());
     expect(composedJson).toEqual("");
+});
+
+test("nodeNamesAreSerialized", () => {
+    const node = Tree.createNode("root", b => b.pushName("My Root Node"));
+
+    const composedJson = Tree.Serializer.composeJson(node);
+    expect(composedJson).toEqual(Utils.formatJson(`{
+        "$type": "root",
+        "$name": "My Root Node"
+    }`));
+});
+
+test("emptyNodeNamesAreNotSerialized", () => {
+    const node = Tree.createNode("root", b => b.pushName(""));
+
+    const composedJson = Tree.Serializer.composeJson(node);
+    expect(composedJson).toEqual(Utils.formatJson(`{
+        "$type": "root"
+    }`));
 });

--- a/tests/unit/tree/tree.test.ts
+++ b/tests/unit/tree/tree.test.ts
@@ -76,10 +76,24 @@ test("noneNodesCannotHaveFields", () => {
     }).toThrowError();
 });
 
+test("nodeName", () => {
+    const testTree = createTestTree();
+    expect(testTree.name).toEqual("TestNode1");
+});
+
+test("nodeNameUndefined", () => {
+    expect(() => {
+        const noneNode = Tree.createNoneNode();
+        expect(noneNode).toEqual(undefined);
+    }).toThrowError();
+});
+
 function createTestTree(): Tree.INode {
     return Tree.createNode("node1", b => {
+        b.pushName("TestNode1");
         b.pushNodeArrayField("field1", [
             Tree.createNode("node2", b => {
+                b.pushName("TestNode2");
                 b.pushNodeField("field2", Tree.createNode("node3"));
             }),
         ]);

--- a/tests/unit/treepack/serializer.test.ts
+++ b/tests/unit/treepack/serializer.test.ts
@@ -20,7 +20,8 @@ test("savedJsonIsIdenticalToReadJson", () => {
                         { "name": "field", "valueType": "boolean" }
                     ]
                 }
-            ]
+            ],
+            "featureNodeNames": true
         },
         "tree": {
             "$type": "NodeA",

--- a/tests/unit/treescheme/instantiator.test.ts
+++ b/tests/unit/treescheme/instantiator.test.ts
@@ -8,6 +8,7 @@ import * as TreeScheme from "../../../src/treescheme";
 test("missingFieldsAreAppendedCorrectly", () => {
     const scheme = createTestScheme();
     const tree = Tree.createNode("Node1", b => {
+        b.pushName("MyNode");
         b.pushNumberField("field2", 1337);
         b.pushNodeArrayField("field9", [
             Tree.createNode("Node1", b => {
@@ -17,6 +18,7 @@ test("missingFieldsAreAppendedCorrectly", () => {
     });
     expect(TreeScheme.Instantiator.duplicateWithMissingFields(scheme, tree)).
         toEqual(Tree.createNode("Node1", b => {
+            b.pushName("MyNode");
             b.pushStringField("field1", "");
             b.pushNumberField("field2", 1337);
             b.pushBooleanField("field3", false);
@@ -61,6 +63,7 @@ test("nodeTypeCanBeChangedIntoNoneType", () => {
 test("whenChangingNodeTypeCompatibleFieldsAreReused", () => {
     const scheme = createTestScheme();
     const node = Tree.createNode("RandomNode", b => {
+        b.pushName("My Node");
         b.pushNumberField("field1", 1234);
         b.pushNumberField("field2", 1337);
         b.pushNodeArrayField("field9", [
@@ -72,6 +75,7 @@ test("whenChangingNodeTypeCompatibleFieldsAreReused", () => {
     });
     expect(TreeScheme.Instantiator.changeNodeType(scheme, node, "Node1")).
         toEqual(Tree.createNode("Node1", b => {
+            b.pushName("My Node");
             b.pushStringField("field1", "");
             b.pushNumberField("field2", 1337);
             b.pushBooleanField("field3", false);

--- a/tests/unit/treescheme/instantiator.test.ts
+++ b/tests/unit/treescheme/instantiator.test.ts
@@ -134,6 +134,7 @@ test("newElementsCanBeCreated", () => {
 
 function createTestScheme(): TreeScheme.IScheme {
     return TreeScheme.createScheme("Root", b => {
+        b.allowFeatures(TreeScheme.Features.NodeNames);
         const alias = b.pushAlias("Root", ["Node1"]);
         const enumeration = b.pushEnum("Enum", [{ value: 1, name: "A" }, { value: 2, name: "B" }]);
         b.pushNodeDefinition("Node1", b => {

--- a/tests/unit/treescheme/serializer.test.ts
+++ b/tests/unit/treescheme/serializer.test.ts
@@ -32,7 +32,8 @@ test("savedJsonIsIdenticalToReadJson", () => {
                     { "name": "field5", "valueType": "Enum", "isArray": true }
                 ]
             }
-        ]
+        ],
+        "featureNodeNames": true
     }`);
     const parseResult = TreeScheme.Parser.parseJson(json);
     expect(parseResult.kind).toBe("success");

--- a/tests/unit/treescheme/treescheme.test.ts
+++ b/tests/unit/treescheme/treescheme.test.ts
@@ -235,3 +235,19 @@ test("aliasDefaultReturnsAsExpected", () => {
     });
     expect(TreeScheme.getDefaultDefinition(scheme, scheme.rootAlias).nodeType).toBe("Node1");
 });
+
+test("checkFeatureSupport", () => {
+    const schemeWithoutNaming = TreeScheme.createScheme("Alias1", b => {
+        b.pushAlias("Alias1", ["Node1"]);
+        b.pushNodeDefinition("Node1");
+    });
+    expect(TreeScheme.featureSupported(schemeWithoutNaming, TreeScheme.Features.NodeNames)).toBe(false);
+
+    const schemeWithNaming = TreeScheme.createScheme("Alias1", b => {
+        b.allowFeatures(TreeScheme.Features.NodeNames);
+        b.pushAlias("Alias1", ["Node1"]);
+        b.pushNodeDefinition("Node1");
+    });
+    expect(TreeScheme.featureSupported(schemeWithNaming, TreeScheme.Features.NodeNames)).toBe(true);
+});
+

--- a/tests/unit/treescheme/validator.test.ts
+++ b/tests/unit/treescheme/validator.test.ts
@@ -107,3 +107,41 @@ test("nodeDefinitionCanHaveTheSameNameAsAnAlias", () => {
     });
     expect(TreeScheme.Validator.validate(scheme, tree)).toBe(true);
 });
+
+test("validateAllowsNodeNamesIfSupportedByScheme", () => {
+    const scheme = TreeScheme.createScheme("Alias1", b => {
+        b.allowFeatures(TreeScheme.Features.NodeNames);
+        b.pushAlias("Alias1", ["Node1"]);
+
+        b.pushNodeDefinition("Node1", b => {
+            b.pushField("field1", "string");
+            b.pushField("field2", "number");
+        });
+    });
+
+    const tree = Tree.createNode("Node1", b => {
+        b.pushName("Hello World");
+        b.pushStringField("field1", "test");
+        b.pushNumberField("field2", 1337);
+    });
+    expect(TreeScheme.Validator.validate(scheme, tree)).toBe(true);
+});
+
+
+test("validateDisallowsNodeNamesIfNotSupportedByScheme", () => {
+    const scheme = TreeScheme.createScheme("Alias1", b => {
+        b.pushAlias("Alias1", ["Node1"]);
+
+        b.pushNodeDefinition("Node1", b => {
+            b.pushField("field1", "string");
+            b.pushField("field2", "number");
+        });
+    });
+
+    const tree = Tree.createNode("Node1", b => {
+        b.pushName("Hello World");
+        b.pushStringField("field1", "test");
+        b.pushNumberField("field2", 1337);
+    });
+    expect(TreeScheme.Validator.validate(scheme, tree)).not.toBe(true);
+});

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,8 @@
     "no-shadowed-variable": false,
     "prefer-for-of": false,
     "max-classes-per-file": false,
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-bitwise": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Support adding a name to the nodes:
![image](https://user-images.githubusercontent.com/14230060/192096278-093606aa-6da1-474c-96b3-2159ee8dbd56.png)
Naming nodes is allowed if the tree-scheme supports the `featureNodeName` feature. In the output tree the names are stored in a `$name` field. 